### PR TITLE
View Layout Copier v1.1.0: solution filter, view types, layout preview, selective copy options

### DIFF
--- a/tools/view-layout-copier/README.md
+++ b/tools/view-layout-copier/README.md
@@ -8,7 +8,7 @@ View Layout Copier simplifies keeping view layouts consistent across a table. In
 
 ## Features
 
-- **Solution selector on launch**: Narrow the table list to a specific solution (managed or unmanaged), or work across all tables
+- **Solution selector on launch**: Narrow the table list to an unmanaged solution (managed solutions are excluded — they can't be modified), or work across all tables. Defaults to the current user's preferred solution from the maker portal when one is set, otherwise the first unmanaged solution alphabetically
 - **Persistent, searchable table list**: Search by display name *or* schema/logical name; the list is alphabetized by display name and stays available on the left for quick switching
 - **View types at a glance**: Every view is badged with its type — Default Public View, Public View, Personal View, Associated View, Advanced Find View, Quick Find View, Lookup View, and more
 - **Personal views included**: Copy to/from personal views (userquery) as well as system views (savedquery)
@@ -25,11 +25,11 @@ View Layout Copier simplifies keeping view layouts consistent across a table. In
 
 ## How to Use
 
-1. **Pick a solution** (optional) in the header to narrow the table list
+1. **Pick a solution** on the Tables tab to narrow the table list — it's pre-selected using your maker-portal preferred solution when available
 2. **Select a table** from the searchable list on the left
 3. **Choose the source view** whose layout you want to copy — its layout appears in the preview strip
 4. **Check the target views** to apply the layout to
-5. **Adjust the copy options** (pinned at the bottom of the Tables column) if needed, then click **Copy & publish** — customizations are published automatically and the publish status is shown in the progress list
+5. **Adjust the copy options** on the Configuration tab if needed, then click **Copy & publish** (pinned at the bottom of the left nav) — customizations are published automatically and the publish status is shown in the progress list
 
 ## Technical Details
 

--- a/tools/view-layout-copier/README.md
+++ b/tools/view-layout-copier/README.md
@@ -1,31 +1,42 @@
 # View Layout Copier
 
-A Power Platform ToolBox (PPTB) tool that allows you to copy layout from one view to multiple views of the same entity in a single operation.
+A Power Platform ToolBox (PPTB) tool that copies the layout of one Dataverse view to multiple other views of the same table in a single operation.
 
 ## Overview
 
-View Layout Copier simplifies the process of maintaining consistent view layouts across multiple views in Dataverse. Instead of manually editing each view's layout, you can select a source view and copy its layout to multiple target views at once.
+View Layout Copier simplifies keeping view layouts consistent across a table. Instead of manually editing each view, pick a source view and apply its column layout, sort order, and components configuration to any number of target views at once — system views and personal views alike.
 
 ## Features
 
-- **Entity Selection**: Browse and select from all available Dataverse entities
-- **View Management**: View all system views for the selected entity
-- **Layout Copying**: Copy the layout from one view to multiple other views
-- **Real-time Progress**: See the status of each view update in real-time
-- **Error Handling**: Clear feedback on success and failure for each view update
+- **Solution selector on launch**: Narrow the table list to a specific solution (managed or unmanaged), or work across all tables
+- **Persistent, searchable table list**: Search by display name *or* schema/logical name; the list is alphabetized by display name and stays available on the left for quick switching
+- **View types at a glance**: Every view is badged with its type — Default Public View, Public View, Personal View, Associated View, Advanced Find View, Quick Find View, Lookup View, and more
+- **Personal views included**: Copy to/from personal views (userquery) as well as system views (savedquery)
+- **Source layout preview**: See the source view's columns — order, display names, and relative widths — plus its sort order before copying
+- **Selective copying**: Choose what to copy (all enabled by default):
+  - **Column layout** — columns, order, and widths
+  - **Sort order** — replaces the targets' sorting
+  - **Components configuration** — custom controls / grid components (`layoutjson`)
+- **Filters are never copied**: Each target view keeps its own filter criteria by design
+- **Smart query merging**: Attributes referenced by the copied layout are added to the target's fetchxml automatically; related-table (link-entity) columns are carried over *without* their filters
+- **Lookup view safety check**: If a lookup view is selected as a target and the source layout's first column is not the table's primary name column, the tool warns you — lookup views need the name column first to work correctly on forms
+- **Single publish**: Customizations are published once per copy operation, not once per view
+- **Real-time progress**: Per-view status with details of what was changed
 
 ## How to Use
 
-1. **Select Entity**: Choose the entity whose views you want to work with
-2. **Select Source View**: Pick the view whose layout you want to copy
-3. **Select Target Views**: Choose one or more views to apply the layout to
-4. **Copy**: Click the "Copy Layout" button to apply the changes
+1. **Pick a solution** (optional) in the header to narrow the table list
+2. **Select a table** from the searchable list on the left
+3. **Choose the source view** whose layout you want to copy — its layout appears in the preview strip
+4. **Check the target views** to apply the layout to
+5. **Adjust the copy options** (pinned at the bottom of the Tables column) if needed, then click **Copy & publish** — customizations are published automatically and the publish status is shown in the progress list
 
 ## Technical Details
 
-- **Built with**: React 18 + TypeScript + Vite
-- **PPTB Integration**: Uses the latest @pptb/types (v1.0.12)
-- **Dataverse API**: Leverages Dataverse Web API for all operations
+- **Built with**: React 18 + TypeScript + Vite (no UI framework dependencies)
+- **PPTB Integration**: Uses `@pptb/types` (`window.dataverseAPI` / `window.toolboxAPI`)
+- **Dataverse**: Reads `savedquery`/`userquery`, merges `layoutxml`/`fetchxml`/`layoutjson`, publishes via `PublishXml`
+- **Theme aware**: Follows the PPTB light/dark theme
 
 ## Installation
 
@@ -37,12 +48,14 @@ This tool is designed to be installed through Power Platform ToolBox. Follow the
 # Install dependencies
 npm install
 
-# Run development server
+# Run development server (demo mode)
 npm run dev
 
 # Build for production
 npm run build
 ```
+
+When run locally outside PPTB (`npm run dev`), the tool starts in **demo mode** with an in-memory mock of the Dataverse API and sample tables/views, so the whole flow — including copying — can be exercised in a plain browser. Production builds require PPTB.
 
 ## License
 

--- a/tools/view-layout-copier/npm-shrinkwrap.json
+++ b/tools/view-layout-copier/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@power-maverick/tool-view-layout-copier",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "GPL-2.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/tools/view-layout-copier/npm-shrinkwrap.json
+++ b/tools/view-layout-copier/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@power-maverick/tool-view-layout-copier",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "GPL-2.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/tools/view-layout-copier/npm-shrinkwrap.json
+++ b/tools/view-layout-copier/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@power-maverick/tool-view-layout-copier",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "GPL-2.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/tools/view-layout-copier/npm-shrinkwrap.json
+++ b/tools/view-layout-copier/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@power-maverick/tool-view-layout-copier",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "GPL-2.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/tools/view-layout-copier/package.json
+++ b/tools/view-layout-copier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
   "displayName": "View Layout Copier",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Copy column layout, sort order and components configuration from one view to multiple views of the same table in a single operation",
   "icon": "icons/layoutReplicator.svg",
   "contributors": [

--- a/tools/view-layout-copier/package.json
+++ b/tools/view-layout-copier/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
   "displayName": "View Layout Copier",
-  "version": "1.0.5",
-  "description": "Copy layout from one view to multiple views of the same entity in a single operation",
+  "version": "1.1.0",
+  "description": "Copy column layout, sort order and components configuration from one view to multiple views of the same table in a single operation",
+  "icon": "icons/layoutReplicator.svg",
   "contributors": [
     {
       "name": "Power Maverick",

--- a/tools/view-layout-copier/package.json
+++ b/tools/view-layout-copier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
   "displayName": "View Layout Copier",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Copy column layout, sort order and components configuration from one view to multiple views of the same table in a single operation",
   "icon": "icons/layoutReplicator.svg",
   "contributors": [

--- a/tools/view-layout-copier/package.json
+++ b/tools/view-layout-copier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
   "displayName": "View Layout Copier",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Copy column layout, sort order and components configuration from one view to multiple views of the same table in a single operation",
   "icon": "icons/layoutReplicator.svg",
   "contributors": [

--- a/tools/view-layout-copier/src/App.tsx
+++ b/tools/view-layout-copier/src/App.tsx
@@ -1,363 +1,402 @@
-import { useEffect, useState } from "react";
-import { Entity, View } from "./models/interfaces";
-import { DataverseClient } from "./utils/DataverseClient";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CopyPanel } from "./components/CopyPanel";
+import { LayoutPreview } from "./components/LayoutPreview";
+import { SolutionPicker } from "./components/SolutionPicker";
+import { TableSidebar } from "./components/TableSidebar";
+import { ViewListPanel } from "./components/ViewListPanel";
+import { CopyOptions, CopyResultItem, Solution, TableInfo, ViewInfo } from "./models/interfaces";
+import { isLookupView, viewTypeRank } from "./models/viewTypes";
+import { DataverseClient, ViewUpdatePayload } from "./utils/DataverseClient";
+import { buildTargetLayoutXml, mergeFetchXml, parseLayoutColumns } from "./utils/layoutUtils";
 
-interface UpdateProgress {
-    viewId: string;
-    viewName: string;
-    status: "pending" | "success" | "error";
-    message?: string;
-}
+const client = new DataverseClient();
 
 function App() {
-    const [isPPTB, setIsPPTB] = useState<boolean>(false);
+    const isDemoMode = (window as any).__PPTB_MOCK__ === true;
+
     const [connectionUrl, setConnectionUrl] = useState<string>("");
-    const [loading, setLoading] = useState<boolean>(true);
+    const [fatalError, setFatalError] = useState<string>("");
     const [error, setError] = useState<string>("");
+    const errorTimer = useRef<number>();
 
-    // Step 1: Entity Selection
-    const [entities, setEntities] = useState<Entity[]>([]);
-    const [selectedEntity, setSelectedEntity] = useState<string>("");
+    // Solutions + tables
+    const [solutions, setSolutions] = useState<Solution[]>([]);
+    const [selectedSolutionId, setSelectedSolutionId] = useState<string>("");
+    const [tables, setTables] = useState<TableInfo[]>([]);
+    const [solutionTableIds, setSolutionTableIds] = useState<Set<string> | null>(null);
+    const [loadingTables, setLoadingTables] = useState<boolean>(true);
 
-    // Step 2: View Selection
-    const [views, setViews] = useState<View[]>([]);
-    const [sourceView, setSourceView] = useState<string>("");
-    const [sourceViewLayout, setSourceViewLayout] = useState<string>("");
-    const [targetViews, setTargetViews] = useState<string[]>([]);
+    // Selected table + its views
+    const [selectedTable, setSelectedTable] = useState<string>("");
+    const [views, setViews] = useState<ViewInfo[]>([]);
+    const [attributeNames, setAttributeNames] = useState<Map<string, string>>(new Map());
+    const [loadingViews, setLoadingViews] = useState<boolean>(false);
 
-    // Step 3: Copy Progress
+    // Copy configuration
+    const [sourceViewId, setSourceViewId] = useState<string>("");
+    const [targetIds, setTargetIds] = useState<Set<string>>(new Set());
+    const [options, setOptions] = useState<CopyOptions>({ columnLayout: true, sortOrder: true, components: true });
     const [isCopying, setIsCopying] = useState<boolean>(false);
-    const [updateProgress, setUpdateProgress] = useState<UpdateProgress[]>([]);
+    const [results, setResults] = useState<CopyResultItem[]>([]);
+    const [publishStatus, setPublishStatus] = useState<"pending" | "success" | "error" | null>(null);
+    const [publishMessage, setPublishMessage] = useState<string>("");
 
-    // Detect environment and initialize
+    const clearResults = () => {
+        setResults([]);
+        setPublishStatus(null);
+        setPublishMessage("");
+    };
+
+    const table = tables.find((t) => t.logicalName === selectedTable);
+    const sourceView = views.find((v) => v.id === sourceViewId);
+
+    const showError = useCallback((message: string) => {
+        setError(message);
+        window.clearTimeout(errorTimer.current);
+        errorTimer.current = window.setTimeout(() => setError(""), 8000);
+    }, []);
+
+    // ---------------------------------------------------------------- boot
     useEffect(() => {
-        const initializeEnvironment = async () => {
-            // Check if we're in PPTB
-            if (window.toolboxAPI) {
-                setIsPPTB(true);
+        const initialize = async () => {
+            if (!window.dataverseAPI) {
+                setFatalError("Not running in Power Platform ToolBox (PPTB). This tool requires PPTB.");
+                setLoadingTables(false);
+                return;
+            }
 
-                try {
-                    const activeConnection = await window.toolboxAPI.connections.getActiveConnection();
-                    setConnectionUrl(activeConnection?.url || "");
-                } catch (error) {
-                    console.error("Failed to get connection:", error);
-                }
+            try {
+                const activeConnection = await window.toolboxAPI?.connections.getActiveConnection();
+                setConnectionUrl(activeConnection?.url || "");
+            } catch (e) {
+                console.error("Failed to get connection:", e);
+            }
 
-                setLoading(false);
-            } else {
-                setError("Not running in Power Platform ToolBox (PPTB). This tool requires PPTB.");
-                setLoading(false);
+            try {
+                const [solutionList, tableList] = await Promise.all([client.listSolutions(), client.listTables()]);
+                setSolutions(solutionList);
+                setTables(tableList);
+            } catch (e: any) {
+                setFatalError(`Failed to load environment metadata: ${e.message}`);
+            } finally {
+                setLoadingTables(false);
             }
         };
 
-        initializeEnvironment();
+        initialize();
+        return () => window.clearTimeout(errorTimer.current);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // Load entities when connection is available
-    useEffect(() => {
-        if (connectionUrl) {
-            loadEntities();
-        }
-    }, [connectionUrl]);
-
-    // Load views when entity is selected
-    useEffect(() => {
-        if (selectedEntity) {
-            loadViews();
-        } else {
-            setViews([]);
-            setSourceView("");
-            setTargetViews([]);
-        }
-    }, [selectedEntity]);
-
-    // Load source view layout when source view is selected
-    useEffect(() => {
-        if (sourceView) {
-            loadSourceViewLayout();
-        } else {
-            setSourceViewLayout("");
-        }
-    }, [sourceView]);
-
-    const loadEntities = async () => {
-        try {
-            setLoading(true);
-            const client = new DataverseClient();
-
-            const entityList = await client.listEntities();
-            setEntities(entityList);
-        } catch (error: any) {
-            showError(`Failed to load entities: ${error.message}`);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const loadViews = async () => {
-        try {
-            setLoading(true);
-            const client = new DataverseClient();
-
-            const viewList = await client.listViews(selectedEntity);
-            setViews(viewList);
-        } catch (error: any) {
-            showError(`Failed to load views: ${error.message}`);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const loadSourceViewLayout = async () => {
-        try {
-            const client = new DataverseClient();
-
-            const view = await client.getView(sourceView);
-            setSourceViewLayout(view.layoutxml);
-        } catch (error: any) {
-            showError(`Failed to load source view layout: ${error.message}`);
-        }
-    };
-
-    const showError = (message: string) => {
-        setError(message);
-        setTimeout(() => setError(""), 5000);
-    };
-
-    const showNotification = async (title: string, body: string, type: "success" | "error" | "info" = "success") => {
-        if (isPPTB && window.toolboxAPI) {
-            await window.toolboxAPI.utils.showNotification({
-                title,
-                body,
-                type,
-            });
-        }
-    };
-
-    const handleSourceViewChange = (viewId: string) => {
-        setSourceView(viewId);
-        // Remove from target views if it was there
-        setTargetViews(targetViews.filter((id) => id !== viewId));
-    };
-
-    const handleTargetViewToggle = (viewId: string) => {
-        if (viewId === sourceView) return; // Can't select source as target
-
-        if (targetViews.includes(viewId)) {
-            setTargetViews(targetViews.filter((id) => id !== viewId));
-        } else {
-            setTargetViews([...targetViews, viewId]);
-        }
-    };
-
-    const handleCopyLayout = async () => {
-        if (!sourceView || targetViews.length === 0) {
-            showError("Please select a source view and at least one target view");
+    // ------------------------------------------------------- solution filter
+    const handleSolutionSelect = async (solutionId: string) => {
+        setSelectedSolutionId(solutionId);
+        if (!solutionId) {
+            setSolutionTableIds(null);
             return;
         }
-
-        if (!sourceViewLayout) {
-            showError("Source view layout is not available");
-            return;
+        try {
+            setLoadingTables(true);
+            const ids = await client.listSolutionTableIds(solutionId);
+            setSolutionTableIds(ids);
+            // Clear the selected table if it fell out of the filtered list
+            const stillVisible = tables.some((t) => t.logicalName === selectedTable && ids.has(t.metadataId));
+            if (selectedTable && !stillVisible) {
+                setSelectedTable("");
+            }
+        } catch (e: any) {
+            showError(`Failed to load solution tables: ${e.message}`);
+        } finally {
+            setLoadingTables(false);
         }
+    };
 
+    // --------------------------------------------------------- table select
+    useEffect(() => {
+        setViews([]);
+        setAttributeNames(new Map());
+        setSourceViewId("");
+        setTargetIds(new Set());
+        clearResults();
+
+        if (!selectedTable) return;
+
+        let cancelled = false;
+        const load = async () => {
+            try {
+                setLoadingViews(true);
+                const [viewList, attrNames] = await Promise.all([client.listViews(selectedTable), client.listAttributeDisplayNames(selectedTable)]);
+                if (cancelled) return;
+                viewList.sort((a, b) => viewTypeRank(a) - viewTypeRank(b) || a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+                setViews(viewList);
+                setAttributeNames(attrNames);
+            } catch (e: any) {
+                if (!cancelled) showError(`Failed to load views: ${e.message}`);
+            } finally {
+                if (!cancelled) setLoadingViews(false);
+            }
+        };
+        load();
+        return () => {
+            cancelled = true;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedTable]);
+
+    // -------------------------------------------------------- copy handlers
+    const handleSourceSelect = (viewId: string) => {
+        setSourceViewId(viewId);
+        clearResults();
+        setTargetIds((prev) => {
+            if (!prev.has(viewId)) return prev;
+            const next = new Set(prev);
+            next.delete(viewId);
+            return next;
+        });
+    };
+
+    const handleTargetToggle = (viewId: string) => {
+        clearResults();
+        setTargetIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(viewId)) {
+                next.delete(viewId);
+            } else {
+                next.add(viewId);
+            }
+            return next;
+        });
+    };
+
+    const lookupWarningViews = useMemo(() => {
+        if (!sourceView || !table) return [];
+        let firstColumn = "";
+        try {
+            firstColumn = parseLayoutColumns(sourceView.layoutxml).filter((c) => !c.isHidden)[0]?.name ?? "";
+        } catch {
+            return [];
+        }
+        if (firstColumn === table.primaryNameAttribute) return [];
+        return views.filter((v) => targetIds.has(v.id) && isLookupView(v)).map((v) => v.name);
+    }, [sourceView, table, targetIds, views]);
+
+    const handleCopy = async () => {
+        if (!sourceView || !table || targetIds.size === 0) return;
+
+        const targets = views.filter((v) => targetIds.has(v.id));
+        const progress: CopyResultItem[] = targets.map((v) => ({ viewId: v.id, viewName: v.name, status: "pending" }));
+        clearResults();
+        setResults(progress);
         setIsCopying(true);
-        const progress: UpdateProgress[] = targetViews.map((viewId) => ({
-            viewId,
-            viewName: views.find((v) => v.savedqueryid === viewId)?.name || viewId,
-            status: "pending",
-        }));
-        setUpdateProgress(progress);
 
-        const client = new DataverseClient();
+        let requiredColumns: string[] = [];
+        try {
+            requiredColumns = parseLayoutColumns(sourceView.layoutxml).map((c) => c.name);
+        } catch (e: any) {
+            showError(`Could not parse the source view layout: ${e.message}`);
+            setIsCopying(false);
+            setResults([]);
+            return;
+        }
 
         let successCount = 0;
-        let errorCount = 0;
+        let systemViewUpdated = false;
 
-        for (let i = 0; i < targetViews.length; i++) {
-            const viewId = targetViews[i];
-            const viewName = views.find((v) => v.savedqueryid === viewId)?.name || viewId;
-
+        for (let i = 0; i < targets.length; i++) {
+            const target = targets[i];
             try {
-                await client.updateViewLayout(selectedEntity, viewId, sourceViewLayout);
-                progress[i] = {
-                    viewId,
-                    viewName,
-                    status: "success",
-                    message: "Layout updated successfully",
-                };
-                successCount++;
-            } catch (error: any) {
-                progress[i] = {
-                    viewId,
-                    viewName,
-                    status: "error",
-                    message: error.message,
-                };
-                errorCount++;
-            }
+                const payload: ViewUpdatePayload = {};
+                const notes: string[] = [];
 
-            setUpdateProgress([...progress]);
+                if (options.columnLayout) {
+                    payload.layoutxml = buildTargetLayoutXml(sourceView.layoutxml, target.layoutxml);
+                }
+
+                // Even when only the layout is copied, the target fetchxml must
+                // contain every attribute the layout references.
+                const merge = mergeFetchXml(sourceView.fetchxml, target.fetchxml, options.columnLayout ? requiredColumns : [], options.sortOrder);
+                if (merge.changed) {
+                    payload.fetchxml = merge.fetchXml;
+                }
+                if (merge.addedAttributes.length > 0) {
+                    notes.push(`added ${merge.addedAttributes.length} column${merge.addedAttributes.length === 1 ? "" : "s"} to the query`);
+                }
+                if (merge.addedLinkEntities.length > 0) {
+                    notes.push(`added related table link (${merge.addedLinkEntities.join(", ")}) without its filters`);
+                }
+                if (merge.droppedOrders.length > 0) {
+                    notes.push(`skipped sort on ${merge.droppedOrders.join(", ")} (related table not in target)`);
+                }
+
+                if (options.components && sourceView.layoutjson && !target.isPersonal) {
+                    payload.layoutjson = sourceView.layoutjson;
+                }
+
+                if (Object.keys(payload).length === 0) {
+                    progress[i] = { ...progress[i], status: "success", message: "Nothing to change" };
+                } else {
+                    await client.updateView(target, payload);
+                    if (!target.isPersonal) systemViewUpdated = true;
+                    progress[i] = { ...progress[i], status: "success", message: notes.length > 0 ? notes.join("; ") : undefined };
+                }
+                successCount++;
+            } catch (e: any) {
+                progress[i] = { ...progress[i], status: "error", message: e.message };
+            }
+            setResults([...progress]);
+        }
+
+        let publishFailed = false;
+        if (systemViewUpdated) {
+            setPublishStatus("pending");
+            setPublishMessage(`Publishing ${table.displayName}…`);
+            try {
+                await client.publishTable(table.logicalName);
+                setPublishStatus("success");
+                setPublishMessage(`${table.displayName} published`);
+            } catch (e: any) {
+                publishFailed = true;
+                setPublishStatus("error");
+                setPublishMessage(`Publish failed: ${e.message}. Publish the table manually.`);
+                showError(`Views were updated but publishing failed: ${e.message}. Publish the table manually.`);
+            }
+        } else if (successCount > 0) {
+            setPublishStatus("success");
+            setPublishMessage("No publish needed — personal views apply immediately");
         }
 
         setIsCopying(false);
 
-        if (errorCount === 0) {
-            await showNotification("Success", `Layout copied to ${successCount} view(s) successfully`, "success");
-        } else {
-            await showNotification("Completed with errors", `Success: ${successCount}, Failed: ${errorCount}`, "error");
+        // Refresh the views so previews/subsequent copies use the new definitions
+        try {
+            const refreshed = await client.listViews(table.logicalName);
+            refreshed.sort((a, b) => viewTypeRank(a) - viewTypeRank(b) || a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+            setViews(refreshed);
+        } catch {
+            /* non-fatal */
+        }
+
+        const errorCount = targets.length - successCount;
+        if (window.toolboxAPI?.utils?.showNotification) {
+            if (errorCount === 0 && !publishFailed) {
+                await window.toolboxAPI.utils.showNotification({ title: "Layout copied", body: `Copied to ${successCount} view(s) and published.`, type: "success" });
+            } else {
+                await window.toolboxAPI.utils.showNotification({ title: "Completed with errors", body: `Success: ${successCount}, Failed: ${errorCount}`, type: "error" });
+            }
         }
     };
 
     const handleReset = () => {
-        setSelectedEntity("");
-        setSourceView("");
-        setTargetViews([]);
-        setUpdateProgress([]);
+        setSourceViewId("");
+        setTargetIds(new Set());
+        clearResults();
     };
 
-    if (loading && !connectionUrl) {
+    // ---------------------------------------------------------------- render
+    if (fatalError) {
         return (
-            <div className="container">
-                <div className="loading">Loading...</div>
-            </div>
-        );
-    }
-
-    if (error && !isPPTB) {
-        return (
-            <div className="container">
-                <div className="error">{error}</div>
+            <div className="app">
+                <div className="fatal-error">{fatalError}</div>
             </div>
         );
     }
 
     return (
-        <div className="container">
-            {error && <div className="error">{error}</div>}
+        <div className="app">
+            <header className="app-header">
+                <div className="app-title">
+                    <span className="app-title-text">View Layout Copier</span>
+                    {isDemoMode && <span className="tag tag-demo">Demo mode — sample data</span>}
+                </div>
+                {connectionUrl && (
+                    <div className="connection-info" title={connectionUrl}>
+                        {connectionUrl.replace(/^https?:\/\//, "")}
+                    </div>
+                )}
+            </header>
 
-            <div className="content-wrapper">
-                {/* Entity Selection */}
-                <div className="section">
-                    <div className="section-title">Select Entity</div>
-                    <div className="form-group">
-                        <select id="entitySelect" value={selectedEntity} onChange={(e) => setSelectedEntity(e.target.value)} disabled={entities.length === 0 || loading}>
-                            <option value="">-- Select an Entity --</option>
-                            {entities.map((entity) => (
-                                <option key={entity.logicalName} value={entity.logicalName}>
-                                    {entity.displayName} ({entity.logicalName})
-                                </option>
-                            ))}
-                        </select>
+            {error && (
+                <div className="error-banner" role="alert">
+                    {error}
+                </div>
+            )}
+
+            <div className="app-body">
+                <div className="left-col">
+                    <TableSidebar
+                        tables={tables}
+                        solutionTableIds={solutionTableIds}
+                        selectedTable={selectedTable}
+                        onSelect={setSelectedTable}
+                        loading={loadingTables}
+                        headerSlot={<SolutionPicker solutions={solutions} selectedId={selectedSolutionId} onSelect={handleSolutionSelect} disabled={loadingTables && solutions.length === 0} />}
+                    />
+                    <div className="sidebar-copy">
+                        <CopyPanel
+                            options={options}
+                            onOptionsChange={setOptions}
+                            sourceView={sourceView}
+                            targetCount={targetIds.size}
+                            lookupWarningViews={lookupWarningViews}
+                            primaryNameAttribute={table?.primaryNameAttribute ?? "name"}
+                            componentsAvailable={!!sourceView?.layoutjson}
+                            isCopying={isCopying}
+                            results={results}
+                            publishStatus={publishStatus}
+                            publishMessage={publishMessage}
+                            onCopy={handleCopy}
+                            onReset={handleReset}
+                        />
                     </div>
                 </div>
 
-                {/* View Selection */}
-                {selectedEntity && views.length > 0 && (
-                    <div className="main-section">
-                        <div className="section">
-                            <div className="section-title">Select Views</div>
-
-                            <div className="views-container">
-                                {/* Source View Panel */}
-                                <div className="views-panel">
-                                    <div className="panel-header">
-                                        <div className="panel-title">Source View</div>
-                                        <div className="panel-subtitle">Select the view to copy layout from</div>
-                                    </div>
-
-                                    <div className="view-list">
-                                        {views.map((view) => (
-                                            <div
-                                                key={view.savedqueryid}
-                                                className={`view-item ${sourceView === view.savedqueryid ? "source" : ""}`}
-                                                onClick={() => handleSourceViewChange(view.savedqueryid)}
-                                            >
-                                                <input
-                                                    type="radio"
-                                                    name="sourceView"
-                                                    checked={sourceView === view.savedqueryid}
-                                                    onChange={() => handleSourceViewChange(view.savedqueryid)}
-                                                    onClick={(e) => e.stopPropagation()}
-                                                />
-                                                <span>{view.name}</span>
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
-
-                                {/* Target Views Panel */}
-                                {sourceView && (
-                                    <div className="views-panel">
-                                        <div className="panel-header">
-                                            <div className="panel-title">Target Views</div>
-                                            <div className="panel-subtitle">Select views to apply the layout to</div>
-                                        </div>
-
-                                        <div className="view-list">
-                                            {views
-                                                .filter((view) => view.savedqueryid !== sourceView)
-                                                .map((view) => (
-                                                    <div
-                                                        key={view.savedqueryid}
-                                                        className={`view-item ${targetViews.includes(view.savedqueryid) ? "selected" : ""}`}
-                                                        onClick={() => handleTargetViewToggle(view.savedqueryid)}
-                                                    >
-                                                        <input
-                                                            type="checkbox"
-                                                            checked={targetViews.includes(view.savedqueryid)}
-                                                            onChange={() => handleTargetViewToggle(view.savedqueryid)}
-                                                            onClick={(e) => e.stopPropagation()}
-                                                        />
-                                                        <span>{view.name}</span>
-                                                    </div>
-                                                ))}
-                                        </div>
-                                    </div>
-                                )}
+                <main className="main-area">
+                    {!selectedTable && (
+                        <div className="empty-state">
+                            <div className="empty-state-icon" aria-hidden="true">
+                                ⬱
                             </div>
+                            <h2>Select a table on the left to get started</h2>
+                            <ol className="empty-state-steps">
+                                <li>Narrow the list by solution, or search by display or schema name</li>
+                                <li>Pick the source view to copy the layout from — its columns show in a preview</li>
+                                <li>Check the target views to apply it to</li>
+                                <li>Review the copy options at the bottom left, then Copy &amp; publish</li>
+                            </ol>
                         </div>
-                    </div>
-                )}
+                    )}
 
-                {/* Action Bar */}
-                {sourceView && targetViews.length > 0 && (
-                    <div className="action-bar">
-                        <div className="selection-info">
-                            <strong>{targetViews.length}</strong> view(s) selected for copying
-                        </div>
-                        <div className="button-group">
-                            <button className="btn btn-success" onClick={handleCopyLayout} disabled={isCopying}>
-                                {isCopying ? "Copying..." : "✓ Copy Layout"}
-                            </button>
-                            <button className="btn btn-secondary" onClick={handleReset} disabled={isCopying}>
-                                Reset
-                            </button>
-                        </div>
-                    </div>
-                )}
+                    {selectedTable && table && (
+                        <>
+                            <div className="table-heading">
+                                <h2>{table.displayName}</h2>
+                                <span className="table-heading-logical">{table.logicalName}</span>
+                                {loadingViews && <span className="loading-inline">Loading views…</span>}
+                            </div>
 
-                {/* Progress */}
-                {updateProgress.length > 0 && (
-                    <div className="section">
-                        <div className="section-title">Progress</div>
-                        <div className="progress-list">
-                            {updateProgress.map((item) => (
-                                <div key={item.viewId} className={`progress-item ${item.status}`}>
-                                    <span className="status-icon">
-                                        {item.status === "success" && "✓"}
-                                        {item.status === "error" && "✗"}
-                                        {item.status === "pending" && "⋯"}
-                                    </span>
-                                    <div>
-                                        <strong>{item.viewName}</strong>
-                                        {item.message && <span> - {item.message}</span>}
-                                    </div>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-                )}
+                            {sourceView && <LayoutPreview view={sourceView} attributeNames={attributeNames} />}
+
+                            <div className="work-area">
+                                <ViewListPanel mode="source" views={views} selectedId={sourceViewId} onSelect={handleSourceSelect} />
+                                <ViewListPanel
+                                    mode="target"
+                                    views={views}
+                                    sourceId={sourceViewId}
+                                    selectedIds={targetIds}
+                                    onToggle={handleTargetToggle}
+                                    onSelectAll={() => {
+                                        clearResults();
+                                        setTargetIds(new Set(views.filter((v) => v.id !== sourceViewId).map((v) => v.id)));
+                                    }}
+                                    onClearAll={() => {
+                                        clearResults();
+                                        setTargetIds(new Set());
+                                    }}
+                                />
+                            </div>
+                        </>
+                    )}
+                </main>
             </div>
         </div>
     );

--- a/tools/view-layout-copier/src/App.tsx
+++ b/tools/view-layout-copier/src/App.tsx
@@ -59,6 +59,18 @@ function App() {
         errorTimer.current = window.setTimeout(() => setError(""), 8000);
     }, []);
 
+    const fetchSolutionTableIds = useCallback(
+        async (solutionId: string): Promise<Set<string> | null> => {
+            try {
+                return await client.listSolutionTableIds(solutionId);
+            } catch (e: any) {
+                showError(`Failed to load solution tables: ${e.message}`);
+                return null;
+            }
+        },
+        [showError],
+    );
+
     // ---------------------------------------------------------------- boot
     useEffect(() => {
         const initialize = async () => {
@@ -76,9 +88,18 @@ function App() {
             }
 
             try {
-                const [solutionList, tableList] = await Promise.all([client.listSolutions(), client.listTables()]);
+                const [solutionList, tableList, preferredSolutionId] = await Promise.all([client.listSolutions(), client.listTables(), client.getPreferredSolutionId()]);
                 setSolutions(solutionList);
                 setTables(tableList);
+
+                // Default to the user's maker-portal preferred solution when it's one of the
+                // unmanaged solutions we can write to; otherwise fall back to the first
+                // alphabetically. Leaves "All tables" unselected only when no solutions exist.
+                const defaultSolutionId = solutionList.find((s) => s.id === preferredSolutionId)?.id ?? solutionList[0]?.id ?? "";
+                if (defaultSolutionId) {
+                    setSelectedSolutionId(defaultSolutionId);
+                    setSolutionTableIds(await fetchSolutionTableIds(defaultSolutionId));
+                }
             } catch (e: any) {
                 setFatalError(`Failed to load environment metadata: ${e.message}`);
             } finally {
@@ -98,20 +119,17 @@ function App() {
             setSolutionTableIds(null);
             return;
         }
-        try {
-            setLoadingTables(true);
-            const ids = await client.listSolutionTableIds(solutionId);
-            setSolutionTableIds(ids);
+        setLoadingTables(true);
+        const ids = await fetchSolutionTableIds(solutionId);
+        setSolutionTableIds(ids);
+        if (ids) {
             // Clear the selected table if it fell out of the filtered list
             const stillVisible = tables.some((t) => t.logicalName === selectedTable && ids.has(t.metadataId));
             if (selectedTable && !stillVisible) {
                 setSelectedTable("");
             }
-        } catch (e: any) {
-            showError(`Failed to load solution tables: ${e.message}`);
-        } finally {
-            setLoadingTables(false);
         }
+        setLoadingTables(false);
     };
 
     // --------------------------------------------------------- table select

--- a/tools/view-layout-copier/src/App.tsx
+++ b/tools/view-layout-copier/src/App.tsx
@@ -8,6 +8,7 @@ import { CopyOptions, CopyResultItem, Solution, TableInfo, ViewInfo } from "./mo
 import { isLookupView, viewTypeRank } from "./models/viewTypes";
 import { DataverseClient, ViewUpdatePayload } from "./utils/DataverseClient";
 import { buildTargetLayoutXml, mergeFetchXml, parseLayoutColumns } from "./utils/layoutUtils";
+import { version as APP_VERSION } from "../package.json";
 
 const client = new DataverseClient();
 
@@ -306,6 +307,7 @@ function App() {
             <header className="app-header">
                 <div className="app-title">
                     <span className="app-title-text">View Layout Copier</span>
+                    <span className="app-version">v{APP_VERSION}</span>
                     {isDemoMode && <span className="tag tag-demo">Demo mode — sample data</span>}
                 </div>
                 {connectionUrl && (

--- a/tools/view-layout-copier/src/App.tsx
+++ b/tools/view-layout-copier/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CopyPanel } from "./components/CopyPanel";
+import { ConfigurationPanel } from "./components/ConfigurationPanel";
+import { CopyActionsBar } from "./components/CopyActionsBar";
 import { LayoutPreview } from "./components/LayoutPreview";
 import { SolutionPicker } from "./components/SolutionPicker";
 import { TableSidebar } from "./components/TableSidebar";
@@ -34,6 +35,7 @@ function App() {
     const [loadingViews, setLoadingViews] = useState<boolean>(false);
 
     // Copy configuration
+    const [leftTab, setLeftTab] = useState<"tables" | "configuration">("tables");
     const [sourceViewId, setSourceViewId] = useState<string>("");
     const [targetIds, setTargetIds] = useState<Set<string>>(new Set());
     const [options, setOptions] = useState<CopyOptions>({ columnLayout: true, sortOrder: true, components: true });
@@ -325,23 +327,43 @@ function App() {
 
             <div className="app-body">
                 <div className="left-col">
-                    <TableSidebar
-                        tables={tables}
-                        solutionTableIds={solutionTableIds}
-                        selectedTable={selectedTable}
-                        onSelect={setSelectedTable}
-                        loading={loadingTables}
-                        headerSlot={<SolutionPicker solutions={solutions} selectedId={selectedSolutionId} onSelect={handleSolutionSelect} disabled={loadingTables && solutions.length === 0} />}
-                    />
+                    <div className="left-tabs" role="tablist">
+                        <button type="button" role="tab" aria-selected={leftTab === "tables"} className={`left-tab ${leftTab === "tables" ? "active" : ""}`} onClick={() => setLeftTab("tables")}>
+                            Tables
+                        </button>
+                        <button
+                            type="button"
+                            role="tab"
+                            aria-selected={leftTab === "configuration"}
+                            className={`left-tab ${leftTab === "configuration" ? "active" : ""}`}
+                            onClick={() => setLeftTab("configuration")}
+                        >
+                            Configuration
+                        </button>
+                    </div>
+
+                    {/* Both tab panels stay mounted so search text and scroll position survive tab switches */}
+                    <div className="left-tab-content" hidden={leftTab !== "tables"}>
+                        <TableSidebar
+                            tables={tables}
+                            solutionTableIds={solutionTableIds}
+                            selectedTable={selectedTable}
+                            onSelect={setSelectedTable}
+                            loading={loadingTables}
+                            headerSlot={<SolutionPicker solutions={solutions} selectedId={selectedSolutionId} onSelect={handleSolutionSelect} disabled={loadingTables && solutions.length === 0} />}
+                        />
+                    </div>
+                    <div className="left-tab-content" hidden={leftTab !== "configuration"}>
+                        <ConfigurationPanel options={options} onOptionsChange={setOptions} componentsAvailable={!!sourceView?.layoutjson} />
+                    </div>
+
                     <div className="sidebar-copy">
-                        <CopyPanel
+                        <CopyActionsBar
                             options={options}
-                            onOptionsChange={setOptions}
                             sourceView={sourceView}
                             targetCount={targetIds.size}
                             lookupWarningViews={lookupWarningViews}
                             primaryNameAttribute={table?.primaryNameAttribute ?? "name"}
-                            componentsAvailable={!!sourceView?.layoutjson}
                             isCopying={isCopying}
                             results={results}
                             publishStatus={publishStatus}
@@ -363,7 +385,7 @@ function App() {
                                 <li>Narrow the list by solution, or search by display or schema name</li>
                                 <li>Pick the source view to copy the layout from — its columns show in a preview</li>
                                 <li>Check the target views to apply it to</li>
-                                <li>Review the copy options at the bottom left, then Copy &amp; publish</li>
+                                <li>Adjust what gets copied on the Configuration tab, then Copy &amp; publish</li>
                             </ol>
                         </div>
                     )}

--- a/tools/view-layout-copier/src/components/ConfigurationPanel.tsx
+++ b/tools/view-layout-copier/src/components/ConfigurationPanel.tsx
@@ -1,0 +1,46 @@
+import { CopyOptions } from "../models/interfaces";
+
+interface ConfigurationPanelProps {
+    options: CopyOptions;
+    onOptionsChange: (options: CopyOptions) => void;
+    componentsAvailable: boolean;
+}
+
+export function ConfigurationPanel({ options, onOptionsChange, componentsAvailable }: ConfigurationPanelProps) {
+    const toggle = (key: keyof CopyOptions) => onOptionsChange({ ...options, [key]: !options[key] });
+
+    return (
+        <div className="config-panel">
+            <div className="config-section">
+                <div className="config-section-title">Copy options</div>
+                <div className="config-section-subtitle">What to copy to the target views</div>
+
+                <label className="option-item">
+                    <input type="checkbox" checked={options.columnLayout} onChange={() => toggle("columnLayout")} />
+                    <span>
+                        <span className="option-name">Column layout</span>
+                        <span className="option-detail">Columns, order and widths</span>
+                    </span>
+                </label>
+                <label className="option-item">
+                    <input type="checkbox" checked={options.sortOrder} onChange={() => toggle("sortOrder")} />
+                    <span>
+                        <span className="option-name">Sort order</span>
+                        <span className="option-detail">Replaces the targets' sorting</span>
+                    </span>
+                </label>
+                <label className={`option-item ${!componentsAvailable ? "disabled" : ""}`}>
+                    <input type="checkbox" checked={options.components && componentsAvailable} disabled={!componentsAvailable} onChange={() => toggle("components")} />
+                    <span>
+                        <span className="option-name">Components configuration</span>
+                        <span className="option-detail">{componentsAvailable ? "Custom controls / grid components" : "Source view has no components configuration"}</span>
+                    </span>
+                </label>
+            </div>
+
+            <div className="filters-note">
+                <span aria-hidden="true">ⓘ</span> View filters are never copied — each target keeps its own filter criteria. Changes are published automatically.
+            </div>
+        </div>
+    );
+}

--- a/tools/view-layout-copier/src/components/CopyActionsBar.tsx
+++ b/tools/view-layout-copier/src/components/CopyActionsBar.tsx
@@ -1,14 +1,12 @@
 import { CopyOptions, CopyResultItem, ViewInfo } from "../models/interfaces";
 
-interface CopyPanelProps {
+interface CopyActionsBarProps {
     options: CopyOptions;
-    onOptionsChange: (options: CopyOptions) => void;
     sourceView?: ViewInfo;
     targetCount: number;
     /** names of selected lookup-view targets when the source's first column is not the primary name attribute */
     lookupWarningViews: string[];
     primaryNameAttribute: string;
-    componentsAvailable: boolean;
     isCopying: boolean;
     results: CopyResultItem[];
     publishStatus: "pending" | "success" | "error" | null;
@@ -17,63 +15,24 @@ interface CopyPanelProps {
     onReset: () => void;
 }
 
-export function CopyPanel({
+export function CopyActionsBar({
     options,
-    onOptionsChange,
     sourceView,
     targetCount,
     lookupWarningViews,
     primaryNameAttribute,
-    componentsAvailable,
     isCopying,
     results,
     publishStatus,
     publishMessage,
     onCopy,
     onReset,
-}: CopyPanelProps) {
+}: CopyActionsBarProps) {
     const nothingToCopy = !options.columnLayout && !options.sortOrder && !options.components;
     const canCopy = !!sourceView && targetCount > 0 && !nothingToCopy && !isCopying;
 
-    const toggle = (key: keyof CopyOptions) => onOptionsChange({ ...options, [key]: !options[key] });
-
     return (
-        <section className="panel copy-panel">
-            <header className="panel-header">
-                <div>
-                    <div className="panel-title">Copy options</div>
-                    <div className="panel-subtitle">What to copy to the targets</div>
-                </div>
-            </header>
-
-            <div className="copy-options">
-                <label className="option-item">
-                    <input type="checkbox" checked={options.columnLayout} onChange={() => toggle("columnLayout")} />
-                    <span>
-                        <span className="option-name">Column layout</span>
-                        <span className="option-detail">Columns, order and widths</span>
-                    </span>
-                </label>
-                <label className="option-item">
-                    <input type="checkbox" checked={options.sortOrder} onChange={() => toggle("sortOrder")} />
-                    <span>
-                        <span className="option-name">Sort order</span>
-                        <span className="option-detail">Replaces the targets' sorting</span>
-                    </span>
-                </label>
-                <label className={`option-item ${!componentsAvailable ? "disabled" : ""}`}>
-                    <input type="checkbox" checked={options.components && componentsAvailable} disabled={!componentsAvailable} onChange={() => toggle("components")} />
-                    <span>
-                        <span className="option-name">Components configuration</span>
-                        <span className="option-detail">{componentsAvailable ? "Custom controls / grid components" : "Source view has no components configuration"}</span>
-                    </span>
-                </label>
-
-                <div className="filters-note">
-                    <span aria-hidden="true">ⓘ</span> View filters are never copied — each target keeps its own filter criteria. Changes are published automatically.
-                </div>
-            </div>
-
+        <section className="panel copy-actions-bar">
             {lookupWarningViews.length > 0 && (
                 <div className="warning-box" role="alert">
                     <strong>Lookup view warning</strong>
@@ -97,7 +56,7 @@ export function CopyPanel({
                     Reset
                 </button>
             </div>
-            {nothingToCopy && <div className="list-hint">Select at least one option to copy.</div>}
+            {nothingToCopy && <div className="list-hint">Enable at least one copy option on the Configuration tab.</div>}
 
             {(results.length > 0 || publishStatus) && (
                 <div className="progress-list">

--- a/tools/view-layout-copier/src/components/CopyPanel.tsx
+++ b/tools/view-layout-copier/src/components/CopyPanel.tsx
@@ -1,0 +1,134 @@
+import { CopyOptions, CopyResultItem, ViewInfo } from "../models/interfaces";
+
+interface CopyPanelProps {
+    options: CopyOptions;
+    onOptionsChange: (options: CopyOptions) => void;
+    sourceView?: ViewInfo;
+    targetCount: number;
+    /** names of selected lookup-view targets when the source's first column is not the primary name attribute */
+    lookupWarningViews: string[];
+    primaryNameAttribute: string;
+    componentsAvailable: boolean;
+    isCopying: boolean;
+    results: CopyResultItem[];
+    publishStatus: "pending" | "success" | "error" | null;
+    publishMessage?: string;
+    onCopy: () => void;
+    onReset: () => void;
+}
+
+export function CopyPanel({
+    options,
+    onOptionsChange,
+    sourceView,
+    targetCount,
+    lookupWarningViews,
+    primaryNameAttribute,
+    componentsAvailable,
+    isCopying,
+    results,
+    publishStatus,
+    publishMessage,
+    onCopy,
+    onReset,
+}: CopyPanelProps) {
+    const nothingToCopy = !options.columnLayout && !options.sortOrder && !options.components;
+    const canCopy = !!sourceView && targetCount > 0 && !nothingToCopy && !isCopying;
+
+    const toggle = (key: keyof CopyOptions) => onOptionsChange({ ...options, [key]: !options[key] });
+
+    return (
+        <section className="panel copy-panel">
+            <header className="panel-header">
+                <div>
+                    <div className="panel-title">Copy options</div>
+                    <div className="panel-subtitle">What to copy to the targets</div>
+                </div>
+            </header>
+
+            <div className="copy-options">
+                <label className="option-item">
+                    <input type="checkbox" checked={options.columnLayout} onChange={() => toggle("columnLayout")} />
+                    <span>
+                        <span className="option-name">Column layout</span>
+                        <span className="option-detail">Columns, order and widths</span>
+                    </span>
+                </label>
+                <label className="option-item">
+                    <input type="checkbox" checked={options.sortOrder} onChange={() => toggle("sortOrder")} />
+                    <span>
+                        <span className="option-name">Sort order</span>
+                        <span className="option-detail">Replaces the targets' sorting</span>
+                    </span>
+                </label>
+                <label className={`option-item ${!componentsAvailable ? "disabled" : ""}`}>
+                    <input type="checkbox" checked={options.components && componentsAvailable} disabled={!componentsAvailable} onChange={() => toggle("components")} />
+                    <span>
+                        <span className="option-name">Components configuration</span>
+                        <span className="option-detail">{componentsAvailable ? "Custom controls / grid components" : "Source view has no components configuration"}</span>
+                    </span>
+                </label>
+
+                <div className="filters-note">
+                    <span aria-hidden="true">ⓘ</span> View filters are never copied — each target keeps its own filter criteria. Changes are published automatically.
+                </div>
+            </div>
+
+            {lookupWarningViews.length > 0 && (
+                <div className="warning-box" role="alert">
+                    <strong>Lookup view warning</strong>
+                    <p>
+                        A lookup view should always have <code>{primaryNameAttribute}</code> (the primary name column) as its <em>first</em> column, otherwise lookups will have difficulty working on
+                        forms. The source layout's first column is different, and it would be applied to:
+                    </p>
+                    <ul>
+                        {lookupWarningViews.map((name) => (
+                            <li key={name}>{name}</li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+
+            <div className="copy-actions">
+                <button type="button" className="btn btn-primary" onClick={onCopy} disabled={!canCopy}>
+                    {isCopying ? "Copying…" : `Copy & publish (${targetCount})`}
+                </button>
+                <button type="button" className="btn btn-secondary" onClick={onReset} disabled={isCopying}>
+                    Reset
+                </button>
+            </div>
+            {nothingToCopy && <div className="list-hint">Select at least one option to copy.</div>}
+
+            {(results.length > 0 || publishStatus) && (
+                <div className="progress-list">
+                    {results.map((item) => (
+                        <div key={item.viewId} className={`progress-item ${item.status}`}>
+                            <span className="status-icon" aria-hidden="true">
+                                {item.status === "success" && "✓"}
+                                {item.status === "error" && "✕"}
+                                {item.status === "pending" && "…"}
+                            </span>
+                            <span className="progress-body">
+                                <span className="progress-name">{item.viewName}</span>
+                                {item.message && <span className="progress-message">{item.message}</span>}
+                            </span>
+                        </div>
+                    ))}
+                    {publishStatus && (
+                        <div className={`progress-item publish-item ${publishStatus}`}>
+                            <span className="status-icon" aria-hidden="true">
+                                {publishStatus === "success" && "✓"}
+                                {publishStatus === "error" && "✕"}
+                                {publishStatus === "pending" && "…"}
+                            </span>
+                            <span className="progress-body">
+                                <span className="progress-name">Publish</span>
+                                {publishMessage && <span className="progress-message">{publishMessage}</span>}
+                            </span>
+                        </div>
+                    )}
+                </div>
+            )}
+        </section>
+    );
+}

--- a/tools/view-layout-copier/src/components/LayoutPreview.tsx
+++ b/tools/view-layout-copier/src/components/LayoutPreview.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from "react";
+import { ViewInfo } from "../models/interfaces";
+import { LayoutColumn, parseLayoutColumns, parseSortOrders, SortOrder } from "../utils/layoutUtils";
+
+interface LayoutPreviewProps {
+    view: ViewInfo;
+    /** attribute logical name -> display name for the current table */
+    attributeNames: Map<string, string>;
+}
+
+function columnDisplayName(column: LayoutColumn, attributeNames: Map<string, string>): string {
+    if (column.name.includes(".")) {
+        const [alias, attribute] = column.name.split(".");
+        return `${alias} › ${attribute}`;
+    }
+    return attributeNames.get(column.name) ?? column.name;
+}
+
+function sortForColumn(column: LayoutColumn, sorts: SortOrder[]): { index: number; descending: boolean } | undefined {
+    const [alias, attribute] = column.name.includes(".") ? column.name.split(".") : [undefined, column.name];
+    const index = sorts.findIndex((s) => s.attribute === attribute && (s.entityAlias ?? undefined) === alias);
+    if (index === -1) return undefined;
+    return { index, descending: sorts[index].descending };
+}
+
+export function LayoutPreview({ view, attributeNames }: LayoutPreviewProps) {
+    const parsed = useMemo(() => {
+        try {
+            return {
+                columns: parseLayoutColumns(view.layoutxml),
+                sorts: parseSortOrders(view.fetchxml),
+                error: undefined as string | undefined,
+            };
+        } catch (error: any) {
+            return { columns: [] as LayoutColumn[], sorts: [] as SortOrder[], error: error.message as string };
+        }
+    }, [view]);
+
+    if (parsed.error) {
+        return <div className="preview-error">Could not parse this view's layout: {parsed.error}</div>;
+    }
+
+    const visible = parsed.columns.filter((c) => !c.isHidden);
+    const totalWidth = visible.reduce((sum, c) => sum + c.width, 0) || 1;
+
+    return (
+        <div className="layout-preview">
+            <div className="layout-preview-header">
+                <span className="layout-preview-title">
+                    Layout of <strong>{view.name}</strong>
+                </span>
+                <span className="layout-preview-meta">
+                    {visible.length} column{visible.length === 1 ? "" : "s"}
+                    {parsed.sorts.length > 0 && (
+                        <>
+                            {" · sorted by "}
+                            {parsed.sorts.map((s, i) => (
+                                <span key={`${s.entityAlias ?? ""}.${s.attribute}`}>
+                                    {i > 0 && ", "}
+                                    <strong>{attributeNames.get(s.attribute) ?? s.attribute}</strong> {s.descending ? "↓" : "↑"}
+                                </span>
+                            ))}
+                        </>
+                    )}
+                </span>
+            </div>
+
+            <div className="layout-columns">
+                {visible.map((column, i) => {
+                    const sort = sortForColumn(column, parsed.sorts);
+                    const isLinked = column.name.includes(".");
+                    return (
+                        <div
+                            key={`${column.name}-${i}`}
+                            className={`layout-column ${isLinked ? "linked" : ""}`}
+                            style={{ flexGrow: column.width, flexBasis: 0 }}
+                            title={`${column.name} — ${column.width}px`}
+                        >
+                            <div className="layout-column-name">
+                                {i + 1}. {columnDisplayName(column, attributeNames)}
+                                {sort && <span className="layout-column-sort">{sort.descending ? " ▼" : " ▲"}</span>}
+                            </div>
+                            <div className="layout-column-detail">
+                                {column.name} · {column.width}px
+                                {isLinked && " · related"}
+                            </div>
+                        </div>
+                    );
+                })}
+                {visible.length === 0 && <div className="list-hint">This view has no visible columns.</div>}
+            </div>
+        </div>
+    );
+}

--- a/tools/view-layout-copier/src/components/SolutionPicker.tsx
+++ b/tools/view-layout-copier/src/components/SolutionPicker.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Solution } from "../models/interfaces";
+
+interface SolutionPickerProps {
+    solutions: Solution[];
+    selectedId: string;
+    onSelect: (solutionId: string) => void;
+    disabled?: boolean;
+}
+
+export function SolutionPicker({ solutions, selectedId, onSelect, disabled }: SolutionPickerProps) {
+    const [open, setOpen] = useState(false);
+    const [search, setSearch] = useState("");
+    const rootRef = useRef<HTMLDivElement>(null);
+    const searchRef = useRef<HTMLInputElement>(null);
+
+    const selected = solutions.find((s) => s.id === selectedId);
+
+    const filtered = useMemo(() => {
+        const term = search.trim().toLowerCase();
+        if (!term) return solutions;
+        return solutions.filter((s) => s.displayName.toLowerCase().includes(term) || s.uniqueName.toLowerCase().includes(term));
+    }, [solutions, search]);
+
+    useEffect(() => {
+        if (!open) return;
+        searchRef.current?.focus();
+
+        const onPointerDown = (e: MouseEvent) => {
+            if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setOpen(false);
+        };
+        document.addEventListener("mousedown", onPointerDown);
+        document.addEventListener("keydown", onKeyDown);
+        return () => {
+            document.removeEventListener("mousedown", onPointerDown);
+            document.removeEventListener("keydown", onKeyDown);
+        };
+    }, [open]);
+
+    const choose = (id: string) => {
+        onSelect(id);
+        setOpen(false);
+        setSearch("");
+    };
+
+    return (
+        <div className="solution-picker" ref={rootRef}>
+            <button type="button" className="solution-picker-trigger" disabled={disabled} onClick={() => setOpen((o) => !o)} aria-haspopup="listbox" aria-expanded={open}>
+                <span className="solution-picker-label">Solution</span>
+                <span className="solution-picker-value">{selected ? selected.displayName : "All tables"}</span>
+                <span className="solution-picker-chevron" aria-hidden="true">
+                    ▾
+                </span>
+            </button>
+
+            {open && (
+                <div className="solution-picker-popup" role="listbox">
+                    <input ref={searchRef} type="text" className="solution-picker-search" placeholder="Filter solutions…" value={search} onChange={(e) => setSearch(e.target.value)} />
+                    <div className="solution-picker-options">
+                        <div className={`solution-picker-option ${selectedId === "" ? "active" : ""}`} role="option" aria-selected={selectedId === ""} onClick={() => choose("")}>
+                            <span className="solution-option-name">All tables</span>
+                            <span className="solution-option-detail">No solution filter</span>
+                        </div>
+                        {filtered.map((s) => (
+                            <div key={s.id} className={`solution-picker-option ${s.id === selectedId ? "active" : ""}`} role="option" aria-selected={s.id === selectedId} onClick={() => choose(s.id)}>
+                                <span className="solution-option-name">
+                                    {s.displayName}
+                                    {s.isManaged && <span className="tag tag-managed">Managed</span>}
+                                </span>
+                                <span className="solution-option-detail">
+                                    {s.uniqueName} · v{s.version}
+                                </span>
+                            </div>
+                        ))}
+                        {filtered.length === 0 && <div className="solution-picker-empty">No solutions match "{search}"</div>}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/tools/view-layout-copier/src/components/SolutionPicker.tsx
+++ b/tools/view-layout-copier/src/components/SolutionPicker.tsx
@@ -68,10 +68,7 @@ export function SolutionPicker({ solutions, selectedId, onSelect, disabled }: So
                         </div>
                         {filtered.map((s) => (
                             <div key={s.id} className={`solution-picker-option ${s.id === selectedId ? "active" : ""}`} role="option" aria-selected={s.id === selectedId} onClick={() => choose(s.id)}>
-                                <span className="solution-option-name">
-                                    {s.displayName}
-                                    {s.isManaged && <span className="tag tag-managed">Managed</span>}
-                                </span>
+                                <span className="solution-option-name">{s.displayName}</span>
                                 <span className="solution-option-detail">
                                     {s.uniqueName} · v{s.version}
                                 </span>

--- a/tools/view-layout-copier/src/components/TableSidebar.tsx
+++ b/tools/view-layout-copier/src/components/TableSidebar.tsx
@@ -30,7 +30,6 @@ export function TableSidebar({ tables, solutionTableIds, selectedTable, onSelect
     return (
         <aside className="sidebar">
             <div className="sidebar-header">
-                <div className="sidebar-title">Tables</div>
                 {headerSlot}
                 <input type="search" className="sidebar-search" placeholder="Search display or schema name…" value={search} onChange={(e) => setSearch(e.target.value)} disabled={loading} />
             </div>

--- a/tools/view-layout-copier/src/components/TableSidebar.tsx
+++ b/tools/view-layout-copier/src/components/TableSidebar.tsx
@@ -1,0 +1,68 @@
+import { ReactNode, useMemo, useState } from "react";
+import { TableInfo } from "../models/interfaces";
+
+interface TableSidebarProps {
+    tables: TableInfo[];
+    /** MetadataIds of tables in the selected solution; null = no solution filter */
+    solutionTableIds: Set<string> | null;
+    selectedTable: string;
+    onSelect: (logicalName: string) => void;
+    loading: boolean;
+    /** rendered in the header above the search bar (e.g. the solution picker) */
+    headerSlot?: ReactNode;
+}
+
+export function TableSidebar({ tables, solutionTableIds, selectedTable, onSelect, loading, headerSlot }: TableSidebarProps) {
+    const [search, setSearch] = useState("");
+
+    const filtered = useMemo(() => {
+        let list = tables;
+        if (solutionTableIds) {
+            list = list.filter((t) => solutionTableIds.has(t.metadataId));
+        }
+        const term = search.trim().toLowerCase();
+        if (term) {
+            list = list.filter((t) => t.displayName.toLowerCase().includes(term) || t.logicalName.toLowerCase().includes(term) || t.schemaName.toLowerCase().includes(term));
+        }
+        return list; // already alphabetized by display name
+    }, [tables, solutionTableIds, search]);
+
+    return (
+        <aside className="sidebar">
+            <div className="sidebar-header">
+                <div className="sidebar-title">Tables</div>
+                {headerSlot}
+                <input type="search" className="sidebar-search" placeholder="Search display or schema name…" value={search} onChange={(e) => setSearch(e.target.value)} disabled={loading} />
+            </div>
+
+            <div className="table-list">
+                {loading && <div className="list-hint">Loading tables…</div>}
+
+                {!loading &&
+                    filtered.map((t) => (
+                        <button
+                            key={t.logicalName}
+                            type="button"
+                            className={`table-item ${t.logicalName === selectedTable ? "active" : ""}`}
+                            onClick={() => onSelect(t.logicalName)}
+                            title={`${t.displayName} (${t.logicalName})`}
+                        >
+                            <span className="table-item-display">{t.displayName}</span>
+                            <span className="table-item-logical">{t.logicalName}</span>
+                        </button>
+                    ))}
+
+                {!loading && filtered.length === 0 && <div className="list-hint">{search ? `No tables match "${search}"` : "No tables in this solution"}</div>}
+            </div>
+
+            <div className="sidebar-footer">
+                {!loading && (
+                    <span>
+                        {filtered.length} table{filtered.length === 1 ? "" : "s"}
+                        {solutionTableIds ? " in solution" : ""}
+                    </span>
+                )}
+            </div>
+        </aside>
+    );
+}

--- a/tools/view-layout-copier/src/components/ViewListPanel.tsx
+++ b/tools/view-layout-copier/src/components/ViewListPanel.tsx
@@ -1,0 +1,76 @@
+import { ViewInfo } from "../models/interfaces";
+import { isLookupView } from "../models/viewTypes";
+import { ViewTypeBadge } from "./ViewTypeBadge";
+
+interface SourcePanelProps {
+    mode: "source";
+    views: ViewInfo[];
+    selectedId: string;
+    onSelect: (viewId: string) => void;
+}
+
+interface TargetPanelProps {
+    mode: "target";
+    views: ViewInfo[];
+    sourceId: string;
+    selectedIds: Set<string>;
+    onToggle: (viewId: string) => void;
+    onSelectAll: () => void;
+    onClearAll: () => void;
+}
+
+type ViewListPanelProps = SourcePanelProps | TargetPanelProps;
+
+export function ViewListPanel(props: ViewListPanelProps) {
+    const isTarget = props.mode === "target";
+    const views = isTarget ? props.views.filter((v) => v.id !== props.sourceId) : props.views;
+
+    return (
+        <section className="panel">
+            <header className="panel-header">
+                <div>
+                    <div className="panel-title">{isTarget ? "Target views" : "Source view"}</div>
+                    <div className="panel-subtitle">{isTarget ? "Apply the layout to these views" : "Copy the layout from this view"}</div>
+                </div>
+                {isTarget && views.length > 0 && (
+                    <div className="panel-actions">
+                        <button type="button" className="link-button" onClick={props.onSelectAll}>
+                            All
+                        </button>
+                        <button type="button" className="link-button" onClick={props.onClearAll}>
+                            None
+                        </button>
+                    </div>
+                )}
+            </header>
+
+            <div className="view-list" role={isTarget ? "group" : "radiogroup"}>
+                {views.map((view) => {
+                    const checked = isTarget ? props.selectedIds.has(view.id) : props.selectedId === view.id;
+                    return (
+                        <label key={view.id} className={`view-item ${checked ? "checked" : ""}`} title={view.description || view.name}>
+                            <input
+                                type={isTarget ? "checkbox" : "radio"}
+                                name={isTarget ? undefined : "source-view"}
+                                checked={checked}
+                                onChange={() => (isTarget ? props.onToggle(view.id) : props.onSelect(view.id))}
+                            />
+                            <span className="view-item-body">
+                                <span className="view-item-name">
+                                    {view.name}
+                                    {isTarget && isLookupView(view) && checked && (
+                                        <span className="lookup-flag" title="Lookup view selected as target — check the first-column warning">
+                                            ⚠
+                                        </span>
+                                    )}
+                                </span>
+                                <ViewTypeBadge view={view} />
+                            </span>
+                        </label>
+                    );
+                })}
+                {views.length === 0 && <div className="list-hint">{isTarget ? "No other views available." : "No views with a layout found for this table."}</div>}
+            </div>
+        </section>
+    );
+}

--- a/tools/view-layout-copier/src/components/ViewTypeBadge.tsx
+++ b/tools/view-layout-copier/src/components/ViewTypeBadge.tsx
@@ -1,0 +1,6 @@
+import { ViewInfo } from "../models/interfaces";
+import { getViewTypeLabel, getViewTypeTone } from "../models/viewTypes";
+
+export function ViewTypeBadge({ view }: { view: Pick<ViewInfo, "querytype" | "isDefault" | "isPersonal"> }) {
+    return <span className={`view-badge view-badge-${getViewTypeTone(view)}`}>{getViewTypeLabel(view)}</span>;
+}

--- a/tools/view-layout-copier/src/main.tsx
+++ b/tools/view-layout-copier/src/main.tsx
@@ -35,14 +35,22 @@ const registerToolboxEvents = () => {
     }
 };
 
-// Apply initial theme
-resolveTheme();
+const bootstrap = async () => {
+    // Outside PPTB during development, run against an in-memory mock so the
+    // tool can be exercised locally with `npm run dev`.
+    if (import.meta.env.DEV && !window.dataverseAPI) {
+        const { installMockAPI } = await import("./mock/mockAPI");
+        installMockAPI();
+    }
 
-// Register event handler
-registerToolboxEvents();
+    resolveTheme();
+    registerToolboxEvents();
 
-createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-        <App />
-    </StrictMode>,
-);
+    createRoot(document.getElementById("root")!).render(
+        <StrictMode>
+            <App />
+        </StrictMode>,
+    );
+};
+
+bootstrap();

--- a/tools/view-layout-copier/src/mock/mockAPI.ts
+++ b/tools/view-layout-copier/src/mock/mockAPI.ts
@@ -1,0 +1,697 @@
+/**
+ * In-browser mock of window.dataverseAPI / window.toolboxAPI so the tool can be
+ * exercised locally (npm run dev) without Power Platform ToolBox.
+ *
+ * Only the API surface this tool uses is implemented. Updates mutate the
+ * in-memory store, so copying layouts visibly "works" in demo mode.
+ */
+
+interface MockView {
+    savedqueryid: string;
+    name: string;
+    description?: string;
+    returnedtypecode: string;
+    querytype: number;
+    isdefault: boolean;
+    fetchxml: string;
+    layoutxml: string;
+    layoutjson: string | null;
+    statecode: number;
+}
+
+interface MockUserView {
+    userqueryid: string;
+    name: string;
+    description?: string;
+    returnedtypecode: string;
+    querytype: number;
+    fetchxml: string;
+    layoutxml: string;
+    statecode: number;
+}
+
+interface MockAttribute {
+    LogicalName: string;
+    DisplayName: { UserLocalizedLabel: { Label: string }; LocalizedLabels: { Label: string; LanguageCode: number }[] };
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function label(text: string) {
+    return { UserLocalizedLabel: { Label: text }, LocalizedLabels: [{ Label: text, LanguageCode: 1033 }] };
+}
+
+function attr(logicalName: string, displayName: string): MockAttribute {
+    return { LogicalName: logicalName, DisplayName: label(displayName) };
+}
+
+function grid(primaryKey: string, cells: Array<[string, number] | [string, number, boolean]>, gridAttrs = 'jump="name" select="1" icon="1" preview="1"'): string {
+    const cellsXml = cells.map(([name, width, hidden]) => `<cell name="${name}" width="${width}"${hidden ? ' ishidden="1"' : ""} />`).join("");
+    return `<grid name="resultset" object="1" ${gridAttrs}><row name="result" id="${primaryKey}">${cellsXml}</row></grid>`;
+}
+
+function fetchXml(entity: string, attributes: string[], orders: Array<[string, boolean]>, filterXml = "", linkXml = ""): string {
+    const attrsXml = attributes.map((a) => `<attribute name="${a}" />`).join("");
+    const ordersXml = orders.map(([a, desc]) => `<order attribute="${a}" descending="${desc}" />`).join("");
+    return `<fetch version="1.0" output-format="xml-platform" mapping="logical"><entity name="${entity}">${attrsXml}${ordersXml}${filterXml}${linkXml}</entity></fetch>`;
+}
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+const SOLUTIONS = [
+    { solutionid: "a1000000-0000-0000-0000-000000000001", friendlyname: "Common Data Services Default Solution", uniquename: "Cr123Default", version: "1.0.0.0", ismanaged: false, isvisible: true },
+    { solutionid: "a1000000-0000-0000-0000-000000000002", friendlyname: "Contoso Sales Core", uniquename: "contoso_salescore", version: "2.4.1.0", ismanaged: false, isvisible: true },
+    { solutionid: "a1000000-0000-0000-0000-000000000003", friendlyname: "Contoso Service Desk", uniquename: "contoso_servicedesk", version: "1.7.0.2", ismanaged: true, isvisible: true },
+    { solutionid: "a1000000-0000-0000-0000-000000000004", friendlyname: "Project Tracker", uniquename: "contoso_projecttracker", version: "0.9.3.0", ismanaged: false, isvisible: true },
+];
+
+const ENTITIES = [
+    {
+        MetadataId: "e0000000-0000-0000-0000-00000000000a",
+        LogicalName: "account",
+        SchemaName: "Account",
+        DisplayName: label("Account"),
+        ObjectTypeCode: 1,
+        PrimaryNameAttribute: "name",
+        IsValidForAdvancedFind: true,
+        IsCustomizable: { Value: true },
+    },
+    {
+        MetadataId: "e0000000-0000-0000-0000-00000000000b",
+        LogicalName: "contact",
+        SchemaName: "Contact",
+        DisplayName: label("Contact"),
+        ObjectTypeCode: 2,
+        PrimaryNameAttribute: "fullname",
+        IsValidForAdvancedFind: true,
+        IsCustomizable: { Value: true },
+    },
+    {
+        MetadataId: "e0000000-0000-0000-0000-00000000000c",
+        LogicalName: "opportunity",
+        SchemaName: "Opportunity",
+        DisplayName: label("Opportunity"),
+        ObjectTypeCode: 3,
+        PrimaryNameAttribute: "name",
+        IsValidForAdvancedFind: true,
+        IsCustomizable: { Value: true },
+    },
+    {
+        MetadataId: "e0000000-0000-0000-0000-00000000000d",
+        LogicalName: "incident",
+        SchemaName: "Incident",
+        DisplayName: label("Case"),
+        ObjectTypeCode: 112,
+        PrimaryNameAttribute: "title",
+        IsValidForAdvancedFind: true,
+        IsCustomizable: { Value: true },
+    },
+    {
+        MetadataId: "e0000000-0000-0000-0000-00000000000e",
+        LogicalName: "contoso_project",
+        SchemaName: "contoso_Project",
+        DisplayName: label("Project"),
+        ObjectTypeCode: 10001,
+        PrimaryNameAttribute: "contoso_name",
+        IsValidForAdvancedFind: true,
+        IsCustomizable: { Value: true },
+    },
+    {
+        MetadataId: "e0000000-0000-0000-0000-00000000000f",
+        LogicalName: "contoso_projecttask",
+        SchemaName: "contoso_ProjectTask",
+        DisplayName: label("Project Task"),
+        ObjectTypeCode: 10002,
+        PrimaryNameAttribute: "contoso_name",
+        IsValidForAdvancedFind: true,
+        IsCustomizable: { Value: true },
+    },
+];
+
+const SOLUTION_COMPONENTS: Record<string, string[]> = {
+    "a1000000-0000-0000-0000-000000000001": ENTITIES.map((e) => e.MetadataId),
+    "a1000000-0000-0000-0000-000000000002": ["e0000000-0000-0000-0000-00000000000a", "e0000000-0000-0000-0000-00000000000b", "e0000000-0000-0000-0000-00000000000c"],
+    "a1000000-0000-0000-0000-000000000003": ["e0000000-0000-0000-0000-00000000000b", "e0000000-0000-0000-0000-00000000000d"],
+    "a1000000-0000-0000-0000-000000000004": ["e0000000-0000-0000-0000-00000000000e", "e0000000-0000-0000-0000-00000000000f"],
+};
+
+const ATTRIBUTES: Record<string, MockAttribute[]> = {
+    account: [
+        attr("name", "Account Name"),
+        attr("accountnumber", "Account Number"),
+        attr("primarycontactid", "Primary Contact"),
+        attr("telephone1", "Main Phone"),
+        attr("emailaddress1", "Email"),
+        attr("address1_city", "City"),
+        attr("address1_stateorprovince", "State/Province"),
+        attr("revenue", "Annual Revenue"),
+        attr("numberofemployees", "Number of Employees"),
+        attr("ownerid", "Owner"),
+        attr("createdon", "Created On"),
+        attr("modifiedon", "Modified On"),
+        attr("statecode", "Status"),
+        attr("industrycode", "Industry"),
+        attr("websiteurl", "Website"),
+    ],
+    contact: [
+        attr("fullname", "Full Name"),
+        attr("firstname", "First Name"),
+        attr("lastname", "Last Name"),
+        attr("emailaddress1", "Email"),
+        attr("telephone1", "Business Phone"),
+        attr("mobilephone", "Mobile Phone"),
+        attr("parentcustomerid", "Company Name"),
+        attr("jobtitle", "Job Title"),
+        attr("address1_city", "City"),
+        attr("ownerid", "Owner"),
+        attr("createdon", "Created On"),
+        attr("modifiedon", "Modified On"),
+    ],
+    opportunity: [
+        attr("name", "Topic"),
+        attr("customerid", "Potential Customer"),
+        attr("estimatedvalue", "Est. Revenue"),
+        attr("estimatedclosedate", "Est. Close Date"),
+        attr("closeprobability", "Probability"),
+        attr("salesstage", "Sales Stage"),
+        attr("ownerid", "Owner"),
+        attr("createdon", "Created On"),
+        attr("modifiedon", "Modified On"),
+    ],
+    incident: [
+        attr("title", "Case Title"),
+        attr("ticketnumber", "Case Number"),
+        attr("customerid", "Customer"),
+        attr("prioritycode", "Priority"),
+        attr("statuscode", "Status Reason"),
+        attr("caseorigincode", "Origin"),
+        attr("ownerid", "Owner"),
+        attr("createdon", "Created On"),
+    ],
+    contoso_project: [
+        attr("contoso_name", "Project Name"),
+        attr("contoso_projectcode", "Project Code"),
+        attr("contoso_startdate", "Start Date"),
+        attr("contoso_enddate", "End Date"),
+        attr("contoso_budget", "Budget"),
+        attr("contoso_status", "Project Status"),
+        attr("ownerid", "Owner"),
+        attr("createdon", "Created On"),
+        attr("modifiedon", "Modified On"),
+    ],
+    contoso_projecttask: [
+        attr("contoso_name", "Task Name"),
+        attr("contoso_projectid", "Project"),
+        attr("contoso_duedate", "Due Date"),
+        attr("contoso_effort", "Effort (hours)"),
+        attr("contoso_complete", "Complete"),
+        attr("ownerid", "Owner"),
+        attr("createdon", "Created On"),
+    ],
+};
+
+let viewIdSeed = 0;
+function nextViewId(): string {
+    viewIdSeed += 1;
+    return `b${String(viewIdSeed).padStart(7, "0")}-0000-0000-0000-000000000000`;
+}
+
+function makeViews(
+    entity: string,
+    primaryKey: string,
+    primaryName: string,
+    defs: Array<{
+        name: string;
+        querytype: number;
+        isdefault?: boolean;
+        cells: Array<[string, number]>;
+        orders?: Array<[string, boolean]>;
+        filter?: string;
+        link?: string;
+        layoutjson?: boolean;
+        description?: string;
+    }>,
+): MockView[] {
+    return defs.map((d) => ({
+        savedqueryid: nextViewId(),
+        name: d.name,
+        description: d.description,
+        returnedtypecode: entity,
+        querytype: d.querytype,
+        isdefault: d.isdefault ?? false,
+        fetchxml: fetchXml(
+            entity,
+            Array.from(new Set([primaryKey.replace("id", "id"), ...d.cells.map(([c]) => c).filter((c) => !c.includes("."))])),
+            d.orders ?? [[primaryName, false]],
+            d.filter ?? "",
+            d.link ?? "",
+        ),
+        layoutxml: grid(primaryKey, d.cells),
+        layoutjson: d.layoutjson ? JSON.stringify({ Name: "resultset", Object: 1, CustomControlDescriptions: [{ ControlDescription: "PowerApps.CoreControls.Grid" }] }) : null,
+        statecode: 0,
+    }));
+}
+
+const ACCOUNT_LINK = `<link-entity name="contact" from="contactid" to="primarycontactid" link-type="outer" alias="primarycontact"><attribute name="emailaddress1" /><filter><condition attribute="statecode" operator="eq" value="0" /></filter></link-entity>`;
+
+const SYSTEM_VIEWS: MockView[] = [
+    ...makeViews("account", "accountid", "name", [
+        {
+            name: "Active Accounts",
+            querytype: 0,
+            isdefault: true,
+            cells: [
+                ["name", 300],
+                ["telephone1", 130],
+                ["address1_city", 130],
+                ["primarycontactid", 180],
+                ["primarycontact.emailaddress1", 200],
+            ],
+            orders: [["name", false]],
+            filter: `<filter type="and"><condition attribute="statecode" operator="eq" value="0" /></filter>`,
+            link: ACCOUNT_LINK,
+            layoutjson: true,
+            description: "Default view: all active accounts.",
+        },
+        {
+            name: "My Active Accounts",
+            querytype: 0,
+            cells: [
+                ["name", 250],
+                ["telephone1", 120],
+                ["emailaddress1", 180],
+                ["modifiedon", 130],
+            ],
+            orders: [["modifiedon", true]],
+            filter: `<filter type="and"><condition attribute="ownerid" operator="eq-userid" /><condition attribute="statecode" operator="eq" value="0" /></filter>`,
+        },
+        {
+            name: "Accounts by Revenue",
+            querytype: 0,
+            cells: [
+                ["name", 280],
+                ["revenue", 140],
+                ["numberofemployees", 120],
+                ["industrycode", 150],
+                ["ownerid", 160],
+            ],
+            orders: [["revenue", true]],
+        },
+        {
+            name: "Accounts by Number",
+            querytype: 0,
+            cells: [
+                ["accountnumber", 130],
+                ["name", 280],
+                ["ownerid", 150],
+            ],
+            orders: [["accountnumber", false]],
+            description: "First column is not the primary name — selecting a lookup view as target should warn.",
+        },
+        {
+            name: "Account Advanced Find View",
+            querytype: 1,
+            cells: [
+                ["name", 300],
+                ["accountnumber", 120],
+                ["telephone1", 130],
+                ["ownerid", 150],
+            ],
+        },
+        {
+            name: "Account Associated View",
+            querytype: 2,
+            cells: [
+                ["name", 250],
+                ["telephone1", 130],
+                ["address1_city", 120],
+            ],
+        },
+        {
+            name: "Quick Find Active Accounts",
+            querytype: 4,
+            cells: [
+                ["name", 250],
+                ["telephone1", 130],
+                ["emailaddress1", 180],
+            ],
+            filter: `<filter type="and" isquickfindfields="1"><condition attribute="name" operator="like" value="{0}" /></filter>`,
+        },
+        {
+            name: "Account Lookup View",
+            querytype: 64,
+            cells: [
+                ["name", 250],
+                ["address1_city", 120],
+            ],
+        },
+    ]),
+    ...makeViews("contact", "contactid", "fullname", [
+        {
+            name: "Active Contacts",
+            querytype: 0,
+            isdefault: true,
+            cells: [
+                ["fullname", 250],
+                ["emailaddress1", 200],
+                ["parentcustomerid", 180],
+                ["telephone1", 130],
+            ],
+        },
+        {
+            name: "My Connections",
+            querytype: 0,
+            cells: [
+                ["fullname", 220],
+                ["jobtitle", 160],
+                ["mobilephone", 130],
+            ],
+        },
+        {
+            name: "Contacts Lookup View",
+            querytype: 64,
+            cells: [
+                ["fullname", 220],
+                ["emailaddress1", 200],
+            ],
+        },
+        {
+            name: "Quick Find Active Contacts",
+            querytype: 4,
+            cells: [
+                ["fullname", 220],
+                ["emailaddress1", 200],
+                ["telephone1", 130],
+            ],
+        },
+        {
+            name: "Contacts Associated View",
+            querytype: 2,
+            cells: [
+                ["fullname", 220],
+                ["emailaddress1", 200],
+                ["jobtitle", 150],
+            ],
+        },
+    ]),
+    ...makeViews("opportunity", "opportunityid", "name", [
+        {
+            name: "Open Opportunities",
+            querytype: 0,
+            isdefault: true,
+            cells: [
+                ["name", 280],
+                ["customerid", 180],
+                ["estimatedvalue", 130],
+                ["estimatedclosedate", 130],
+                ["salesstage", 130],
+            ],
+            orders: [["estimatedclosedate", false]],
+        },
+        {
+            name: "Closing Next Month",
+            querytype: 0,
+            cells: [
+                ["name", 260],
+                ["estimatedvalue", 130],
+                ["closeprobability", 110],
+                ["ownerid", 150],
+            ],
+            orders: [["estimatedvalue", true]],
+        },
+        {
+            name: "Opportunity Lookup View",
+            querytype: 64,
+            cells: [
+                ["name", 260],
+                ["customerid", 180],
+            ],
+        },
+        {
+            name: "Opportunity Advanced Find View",
+            querytype: 1,
+            cells: [
+                ["name", 280],
+                ["customerid", 180],
+                ["estimatedvalue", 130],
+            ],
+        },
+    ]),
+    ...makeViews("incident", "incidentid", "title", [
+        {
+            name: "Active Cases",
+            querytype: 0,
+            isdefault: true,
+            cells: [
+                ["title", 280],
+                ["ticketnumber", 120],
+                ["prioritycode", 100],
+                ["customerid", 180],
+                ["createdon", 130],
+            ],
+            orders: [["createdon", true]],
+        },
+        {
+            name: "My Active Cases",
+            querytype: 0,
+            cells: [
+                ["title", 280],
+                ["prioritycode", 100],
+                ["statuscode", 130],
+            ],
+        },
+        {
+            name: "Case Lookup View",
+            querytype: 64,
+            cells: [
+                ["ticketnumber", 120],
+                ["title", 280],
+            ],
+        },
+        {
+            name: "Cases Associated View",
+            querytype: 2,
+            cells: [
+                ["title", 260],
+                ["ticketnumber", 120],
+                ["statuscode", 130],
+            ],
+        },
+    ]),
+    ...makeViews("contoso_project", "contoso_projectid", "contoso_name", [
+        {
+            name: "Active Projects",
+            querytype: 0,
+            isdefault: true,
+            cells: [
+                ["contoso_name", 280],
+                ["contoso_projectcode", 120],
+                ["contoso_startdate", 120],
+                ["contoso_enddate", 120],
+                ["contoso_status", 130],
+            ],
+        },
+        {
+            name: "Projects over Budget",
+            querytype: 0,
+            cells: [
+                ["contoso_name", 260],
+                ["contoso_budget", 130],
+                ["ownerid", 150],
+            ],
+            orders: [["contoso_budget", true]],
+        },
+        {
+            name: "Project Lookup View",
+            querytype: 64,
+            cells: [
+                ["contoso_name", 260],
+                ["contoso_projectcode", 120],
+            ],
+        },
+        {
+            name: "Project Quick Find",
+            querytype: 4,
+            cells: [
+                ["contoso_name", 260],
+                ["contoso_projectcode", 120],
+            ],
+        },
+    ]),
+    ...makeViews("contoso_projecttask", "contoso_projecttaskid", "contoso_name", [
+        {
+            name: "All Project Tasks",
+            querytype: 0,
+            isdefault: true,
+            cells: [
+                ["contoso_name", 280],
+                ["contoso_projectid", 180],
+                ["contoso_duedate", 120],
+                ["contoso_complete", 100],
+            ],
+        },
+        {
+            name: "Task Associated View",
+            querytype: 2,
+            cells: [
+                ["contoso_name", 260],
+                ["contoso_duedate", 120],
+            ],
+        },
+        { name: "Task Lookup View", querytype: 64, cells: [["contoso_name", 260]] },
+    ]),
+];
+
+const PERSONAL_VIEWS: MockUserView[] = [
+    {
+        userqueryid: nextViewId(),
+        name: "West Region Accounts (mine)",
+        returnedtypecode: "account",
+        querytype: 0,
+        fetchxml: fetchXml(
+            "account",
+            ["name", "address1_stateorprovince", "revenue"],
+            [["name", false]],
+            `<filter type="and"><condition attribute="address1_stateorprovince" operator="eq" value="WA" /></filter>`,
+        ),
+        layoutxml: grid("accountid", [
+            ["name", 280],
+            ["address1_stateorprovince", 120],
+            ["revenue", 130],
+        ]),
+        statecode: 0,
+    },
+    {
+        userqueryid: nextViewId(),
+        name: "My VIP Contacts",
+        returnedtypecode: "contact",
+        querytype: 0,
+        fetchxml: fetchXml("contact", ["fullname", "emailaddress1", "mobilephone"], [["fullname", false]]),
+        layoutxml: grid("contactid", [
+            ["fullname", 240],
+            ["emailaddress1", 200],
+            ["mobilephone", 130],
+        ]),
+        statecode: 0,
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Mock API implementation
+// ---------------------------------------------------------------------------
+
+function getFilterValue(query: string, pattern: RegExp): string | undefined {
+    return pattern.exec(query)?.[1];
+}
+
+export function installMockAPI(): void {
+    const dataverseAPI: any = {
+        async getEntitySetName(logicalName: string): Promise<string> {
+            const irregular: Record<string, string> = {
+                solution: "solutions",
+                solutioncomponent: "solutioncomponents",
+                savedquery: "savedqueries",
+                userquery: "userqueries",
+            };
+            return irregular[logicalName] ?? `${logicalName}s`;
+        },
+
+        async getAllEntitiesMetadata(): Promise<{ value: unknown[] }> {
+            await delay(400);
+            return { value: ENTITIES };
+        },
+
+        async getEntityRelatedMetadata(entityLogicalName: string, relatedPath: string): Promise<{ value: unknown[] }> {
+            await delay(200);
+            if (relatedPath === "Attributes") {
+                return { value: ATTRIBUTES[entityLogicalName] ?? [] };
+            }
+            return { value: [] };
+        },
+
+        async queryData(odataQuery: string): Promise<{ value: unknown[] }> {
+            await delay(300);
+
+            if (odataQuery.startsWith("solutions?")) {
+                return { value: SOLUTIONS };
+            }
+
+            if (odataQuery.startsWith("solutioncomponents?")) {
+                const solutionId = getFilterValue(odataQuery, /_solutionid_value eq ([0-9a-f-]+)/i);
+                const ids = (solutionId && SOLUTION_COMPONENTS[solutionId]) || [];
+                return { value: ids.map((objectid) => ({ objectid })) };
+            }
+
+            if (odataQuery.startsWith("savedqueries?")) {
+                const entity = getFilterValue(odataQuery, /returnedtypecode eq '([^']+)'/);
+                return { value: SYSTEM_VIEWS.filter((v) => v.returnedtypecode === entity) };
+            }
+
+            if (odataQuery.startsWith("userqueries?")) {
+                const entity = getFilterValue(odataQuery, /returnedtypecode eq '([^']+)'/);
+                return { value: PERSONAL_VIEWS.filter((v) => v.returnedtypecode === entity) };
+            }
+
+            return { value: [] };
+        },
+
+        async retrieve(entityLogicalName: string, id: string): Promise<Record<string, unknown>> {
+            await delay(150);
+            if (entityLogicalName === "savedquery") {
+                const view = SYSTEM_VIEWS.find((v) => v.savedqueryid === id);
+                if (view) return view as unknown as Record<string, unknown>;
+            }
+            if (entityLogicalName === "userquery") {
+                const view = PERSONAL_VIEWS.find((v) => v.userqueryid === id);
+                if (view) return view as unknown as Record<string, unknown>;
+            }
+            throw new Error(`Record not found: ${entityLogicalName} ${id}`);
+        },
+
+        async update(entityLogicalName: string, id: string, record: Record<string, unknown>): Promise<void> {
+            await delay(500);
+            const view: any =
+                entityLogicalName === "savedquery" ? SYSTEM_VIEWS.find((v) => v.savedqueryid === id) : entityLogicalName === "userquery" ? PERSONAL_VIEWS.find((v) => v.userqueryid === id) : undefined;
+            if (!view) {
+                throw new Error(`Record not found: ${entityLogicalName} ${id}`);
+            }
+            Object.assign(view, record);
+            console.info(`[mock] Updated ${entityLogicalName} '${view.name}'`, record);
+        },
+
+        async publishCustomizations(tableLogicalName?: string): Promise<void> {
+            await delay(800);
+            console.info(`[mock] Published customizations for ${tableLogicalName ?? "all"}`);
+        },
+    };
+
+    const toolboxAPI: any = {
+        connections: {
+            async getActiveConnection() {
+                return { url: "https://contoso-demo.crm.dynamics.com", name: "Contoso Demo (mock)" };
+            },
+        },
+        utils: {
+            async showNotification(options: { title: string; body: string; type: string }) {
+                console.info(`[mock notification] ${options.type}: ${options.title} — ${options.body}`);
+            },
+            async getCurrentTheme() {
+                return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+            },
+        },
+        events: {
+            on() {
+                /* no-op */
+            },
+            off() {
+                /* no-op */
+            },
+        },
+    };
+
+    (window as any).dataverseAPI = dataverseAPI;
+    (window as any).toolboxAPI = toolboxAPI;
+    (window as any).__PPTB_MOCK__ = true;
+}

--- a/tools/view-layout-copier/src/mock/mockAPI.ts
+++ b/tools/view-layout-copier/src/mock/mockAPI.ts
@@ -67,6 +67,11 @@ const SOLUTIONS = [
     { solutionid: "a1000000-0000-0000-0000-000000000004", friendlyname: "Project Tracker", uniquename: "contoso_projecttracker", version: "0.9.3.0", ismanaged: false, isvisible: true },
 ];
 
+const MOCK_USER_ID = "c0000000-0000-0000-0000-000000000001";
+// Simulates a maker having picked a preferred solution in the maker portal — not the
+// alphabetically-first one, so demo mode exercises the "honor the user's choice" path.
+const MOCK_PREFERRED_SOLUTION_ID = "a1000000-0000-0000-0000-000000000002";
+
 const ENTITIES = [
     {
         MetadataId: "e0000000-0000-0000-0000-00000000000a",
@@ -615,7 +620,14 @@ export function installMockAPI(): void {
             await delay(300);
 
             if (odataQuery.startsWith("solutions?")) {
-                return { value: SOLUTIONS };
+                // Mirrors the real "isvisible eq true and ismanaged eq false" filter this tool sends.
+                return { value: SOLUTIONS.filter((s) => s.ismanaged === false) };
+            }
+
+            if (odataQuery.startsWith("usersettingscollection?")) {
+                const userId = getFilterValue(odataQuery, /systemuserid eq ([0-9a-f-]+)/i);
+                if (userId !== MOCK_USER_ID) return { value: [] };
+                return { value: [{ systemuserid: MOCK_USER_ID, preferredsolution: { solutionid: MOCK_PREFERRED_SOLUTION_ID } }] };
             }
 
             if (odataQuery.startsWith("solutioncomponents?")) {
@@ -664,6 +676,14 @@ export function installMockAPI(): void {
         async publishCustomizations(tableLogicalName?: string): Promise<void> {
             await delay(800);
             console.info(`[mock] Published customizations for ${tableLogicalName ?? "all"}`);
+        },
+
+        async execute(request: { operationName: string; operationType: string }): Promise<Record<string, unknown>> {
+            await delay(100);
+            if (request.operationName === "WhoAmI") {
+                return { UserId: MOCK_USER_ID };
+            }
+            throw new Error(`Mock does not implement operation '${request.operationName}'`);
         },
     };
 

--- a/tools/view-layout-copier/src/models/interfaces.ts
+++ b/tools/view-layout-copier/src/models/interfaces.ts
@@ -3,7 +3,6 @@ export interface Solution {
     uniqueName: string;
     displayName: string;
     version: string;
-    isManaged: boolean;
 }
 
 export interface TableInfo {

--- a/tools/view-layout-copier/src/models/interfaces.ts
+++ b/tools/view-layout-copier/src/models/interfaces.ts
@@ -1,20 +1,42 @@
-export interface Entity {
+export interface Solution {
+    id: string;
+    uniqueName: string;
+    displayName: string;
+    version: string;
+    isManaged: boolean;
+}
+
+export interface TableInfo {
     logicalName: string;
+    schemaName: string;
     displayName: string;
     objectTypeCode: number;
+    metadataId: string;
+    primaryNameAttribute: string;
 }
 
-export interface View {
-    savedqueryid: string;
-    name: string;
-    fetchxml: string;
-    layoutxml: string;
-    returnedtypecode: string;
-    querytype: number;
-}
-
-export interface ViewListItem {
+export interface ViewInfo {
     id: string;
     name: string;
-    type: "system" | "user";
+    description?: string;
+    fetchxml: string;
+    layoutxml: string;
+    layoutjson?: string | null;
+    querytype: number;
+    isDefault: boolean;
+    /** true when the view is a personal view (userquery) instead of a system view (savedquery) */
+    isPersonal: boolean;
+}
+
+export interface CopyOptions {
+    columnLayout: boolean;
+    sortOrder: boolean;
+    components: boolean;
+}
+
+export interface CopyResultItem {
+    viewId: string;
+    viewName: string;
+    status: "pending" | "success" | "error";
+    message?: string;
 }

--- a/tools/view-layout-copier/src/models/viewTypes.ts
+++ b/tools/view-layout-copier/src/models/viewTypes.ts
@@ -1,0 +1,89 @@
+import { ViewInfo } from "./interfaces";
+
+/**
+ * SavedQuery.QueryType values
+ * https://learn.microsoft.com/en-us/power-apps/developer/data-platform/saved-queries
+ */
+export const QUERY_TYPE = {
+    MAIN_APPLICATION_VIEW: 0,
+    ADVANCED_SEARCH: 1,
+    SUB_GRID: 2,
+    QUICK_FIND_SEARCH: 4,
+    REPORTING: 8,
+    OFFLINE_FILTERS: 16,
+    LOOKUP_VIEW: 64,
+    SM_APPOINTMENT_BOOK_VIEW: 128,
+    OUTLOOK_FILTERS: 256,
+    ADDRESS_BOOK_FILTERS: 512,
+    MAIN_APPLICATION_VIEW_WITHOUT_SUBJECT: 1024,
+    OTHER: 2048,
+    INTERACTIVE_WORKFLOW_VIEW: 4096,
+    OFFLINE_TEMPLATE: 8192,
+    CUSTOM_DEFINED_VIEW: 16384,
+} as const;
+
+interface ViewTypeMeta {
+    label: string;
+    /** css badge modifier class */
+    tone: "default" | "public" | "personal" | "lookup" | "quickfind" | "associated" | "advancedfind" | "other";
+}
+
+const QUERY_TYPE_META: Record<number, ViewTypeMeta> = {
+    [QUERY_TYPE.MAIN_APPLICATION_VIEW]: { label: "Public View", tone: "public" },
+    [QUERY_TYPE.ADVANCED_SEARCH]: { label: "Advanced Find View", tone: "advancedfind" },
+    [QUERY_TYPE.SUB_GRID]: { label: "Associated View", tone: "associated" },
+    [QUERY_TYPE.QUICK_FIND_SEARCH]: { label: "Quick Find View", tone: "quickfind" },
+    [QUERY_TYPE.REPORTING]: { label: "Reporting View", tone: "other" },
+    [QUERY_TYPE.OFFLINE_FILTERS]: { label: "Offline Filters", tone: "other" },
+    [QUERY_TYPE.LOOKUP_VIEW]: { label: "Lookup View", tone: "lookup" },
+    [QUERY_TYPE.SM_APPOINTMENT_BOOK_VIEW]: { label: "Appointment Book View", tone: "other" },
+    [QUERY_TYPE.OUTLOOK_FILTERS]: { label: "Outlook Filters", tone: "other" },
+    [QUERY_TYPE.ADDRESS_BOOK_FILTERS]: { label: "Address Book Filters", tone: "other" },
+    [QUERY_TYPE.MAIN_APPLICATION_VIEW_WITHOUT_SUBJECT]: { label: "Main App View", tone: "public" },
+    [QUERY_TYPE.OTHER]: { label: "Other View", tone: "other" },
+    [QUERY_TYPE.INTERACTIVE_WORKFLOW_VIEW]: { label: "Interactive Experience View", tone: "other" },
+    [QUERY_TYPE.OFFLINE_TEMPLATE]: { label: "Offline Template", tone: "other" },
+    [QUERY_TYPE.CUSTOM_DEFINED_VIEW]: { label: "Custom Defined View", tone: "other" },
+};
+
+export function getViewTypeLabel(view: Pick<ViewInfo, "querytype" | "isDefault" | "isPersonal">): string {
+    if (view.isPersonal) {
+        return "Personal View";
+    }
+    if (view.querytype === QUERY_TYPE.MAIN_APPLICATION_VIEW && view.isDefault) {
+        return "Default Public View";
+    }
+    return QUERY_TYPE_META[view.querytype]?.label ?? `View (type ${view.querytype})`;
+}
+
+export function getViewTypeTone(view: Pick<ViewInfo, "querytype" | "isDefault" | "isPersonal">): ViewTypeMeta["tone"] {
+    if (view.isPersonal) {
+        return "personal";
+    }
+    if (view.querytype === QUERY_TYPE.MAIN_APPLICATION_VIEW && view.isDefault) {
+        return "default";
+    }
+    return QUERY_TYPE_META[view.querytype]?.tone ?? "other";
+}
+
+export function isLookupView(view: Pick<ViewInfo, "querytype">): boolean {
+    return view.querytype === QUERY_TYPE.LOOKUP_VIEW;
+}
+
+/** Sort order used to present views: default public first, then public, then the rest, personal last */
+export function viewTypeRank(view: Pick<ViewInfo, "querytype" | "isDefault" | "isPersonal">): number {
+    if (view.isPersonal) return 90;
+    if (view.querytype === QUERY_TYPE.MAIN_APPLICATION_VIEW) return view.isDefault ? 0 : 1;
+    switch (view.querytype) {
+        case QUERY_TYPE.ADVANCED_SEARCH:
+            return 10;
+        case QUERY_TYPE.SUB_GRID:
+            return 20;
+        case QUERY_TYPE.QUICK_FIND_SEARCH:
+            return 30;
+        case QUERY_TYPE.LOOKUP_VIEW:
+            return 40;
+        default:
+            return 50;
+    }
+}

--- a/tools/view-layout-copier/src/styles.css
+++ b/tools/view-layout-copier/src/styles.css
@@ -1,35 +1,79 @@
 :root {
-    --primary-color: #0078d4;
-    --primary-hover: #106ebe;
-    --secondary-color: #6c757d;
-    --secondary-hover: #5a6268;
+    --primary-color: #0f6cbd;
+    --primary-hover: #115ea3;
+    --primary-soft: #ebf3fc;
     --success-color: #107c10;
-    --danger-color: #d13438;
-    --warning-color: #ffc83d;
+    --success-soft: #f1faf1;
+    --danger-color: #c50f1f;
+    --danger-soft: #fdf3f4;
+    --warning-color: #9d5d00;
+    --warning-soft: #fff8ec;
+    --warning-border: #f2c661;
     --background: #ffffff;
-    --surface: #faf9f8;
-    --border-color: #edebe9;
-    --text-color: #323130;
-    --text-secondary: #605e5c;
-    --shadow-sm: 0 1.6px 3.6px rgba(0, 0, 0, 0.132), 0 0.3px 0.9px rgba(0, 0, 0, 0.108);
-    --shadow-md: 0 3.2px 7.2px rgba(0, 0, 0, 0.132), 0 0.6px 1.8px rgba(0, 0, 0, 0.108);
+    --surface: #fafafa;
+    --surface-hover: #f0f0f0;
+    --border-color: #e0e0e0;
+    --border-strong: #c7c7c7;
+    --text-color: #242424;
+    --text-secondary: #616161;
+    --text-faint: #8a8a8a;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.08);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.12);
+    --badge-public-bg: #ebf3fc;
+    --badge-public-fg: #0f548c;
+    --badge-default-bg: #0f6cbd;
+    --badge-default-fg: #ffffff;
+    --badge-personal-bg: #e7f4e7;
+    --badge-personal-fg: #0e700e;
+    --badge-lookup-bg: #f3ebfc;
+    --badge-lookup-fg: #6b3fa0;
+    --badge-quickfind-bg: #e0f5f5;
+    --badge-quickfind-fg: #0a6c6c;
+    --badge-associated-bg: #fdf0e4;
+    --badge-associated-fg: #9c4a10;
+    --badge-advancedfind-bg: #ededed;
+    --badge-advancedfind-fg: #4d4d4d;
+    --badge-other-bg: #ededed;
+    --badge-other-fg: #4d4d4d;
 }
 
 body.dark-theme {
-    --primary-color: #4a9eff;
-    --primary-hover: #6cb0ff;
-    --secondary-color: #6c757d;
-    --secondary-hover: #5a6268;
+    --primary-color: #479ef5;
+    --primary-hover: #62abf5;
+    --primary-soft: #16263d;
     --success-color: #54b054;
-    --danger-color: #f48771;
-    --warning-color: #ffd666;
-    --background: #1e1e1e;
-    --surface: #2d2d2d;
-    --border-color: #3f3f3f;
-    --text-color: #e0e0e0;
-    --text-secondary: #b0b0b0;
-    --shadow-sm: 0 1.6px 3.6px rgba(0, 0, 0, 0.4), 0 0.3px 0.9px rgba(0, 0, 0, 0.3);
-    --shadow-md: 0 3.2px 7.2px rgba(0, 0, 0, 0.4), 0 0.6px 1.8px rgba(0, 0, 0, 0.3);
+    --success-soft: #16290f;
+    --danger-color: #f4707a;
+    --danger-soft: #3b1214;
+    --warning-color: #f2c661;
+    --warning-soft: #32290f;
+    --warning-border: #6b5416;
+    --background: #1b1b1b;
+    --surface: #242424;
+    --surface-hover: #2e2e2e;
+    --border-color: #3a3a3a;
+    --border-strong: #525252;
+    --text-color: #eaeaea;
+    --text-secondary: #adadad;
+    --text-faint: #7a7a7a;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
+    --badge-public-bg: #16263d;
+    --badge-public-fg: #79b8f5;
+    --badge-default-bg: #479ef5;
+    --badge-default-fg: #0a1a2a;
+    --badge-personal-bg: #16290f;
+    --badge-personal-fg: #7fd67f;
+    --badge-lookup-bg: #281a3d;
+    --badge-lookup-fg: #c19af0;
+    --badge-quickfind-bg: #0f2a2a;
+    --badge-quickfind-fg: #5ecccc;
+    --badge-associated-bg: #33200e;
+    --badge-associated-fg: #f0a05e;
+    --badge-advancedfind-bg: #2e2e2e;
+    --badge-advancedfind-fg: #bdbdbd;
+    --badge-other-bg: #2e2e2e;
+    --badge-other-fg: #bdbdbd;
 }
 
 * {
@@ -39,340 +83,842 @@ body.dark-theme {
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-family:
+        "Segoe UI",
+        -apple-system,
+        BlinkMacSystemFont,
+        "Roboto",
+        "Helvetica Neue",
+        sans-serif;
     -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
     background-color: var(--background);
     color: var(--text-color);
-    line-height: 1.5;
+    line-height: 1.45;
+    font-size: 13px;
 }
 
-#root {
+#root,
+.app {
     height: 100vh;
     display: flex;
     flex-direction: column;
-}
-
-.container {
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    padding: 16px;
-    gap: 16px;
     overflow: hidden;
 }
 
-.section {
+/* ------------------------------------------------------------- scrollbars */
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+::-webkit-scrollbar-thumb {
+    background: var(--border-strong);
+    border-radius: 5px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+}
+::-webkit-scrollbar-thumb:hover {
+    background-color: var(--text-faint);
+    background-clip: content-box;
+}
+
+/* ----------------------------------------------------------------- header */
+.app-header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border-color);
     background-color: var(--surface);
-    border-radius: 4px;
-    border: 1px solid var(--border-color);
-    padding: 16px;
-    overflow: auto;
+    flex-shrink: 0;
 }
 
-.section-title {
-    font-size: 14px;
+.app-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.app-title-text {
+    font-size: 15px;
     font-weight: 600;
-    color: var(--text-color);
-    margin-bottom: 12px;
+    white-space: nowrap;
 }
 
-.form-group {
-    margin-bottom: 12px;
+.connection-info {
+    margin-left: auto;
+    font-size: 12px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 260px;
 }
 
-.form-group label {
-    display: block;
-    margin-bottom: 6px;
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text-color);
+.tag {
+    display: inline-flex;
+    align-items: center;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 1px 7px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    white-space: nowrap;
 }
 
-.form-group select,
-.form-group input[type="text"] {
+.tag-demo {
+    background-color: var(--warning-soft);
+    color: var(--warning-color);
+    border: 1px solid var(--warning-border);
+}
+
+.tag-managed {
+    background-color: var(--badge-other-bg);
+    color: var(--badge-other-fg);
+    margin-left: 6px;
+}
+
+/* -------------------------------------------------------- solution picker */
+.solution-picker {
+    position: relative;
     width: 100%;
-    padding: 8px 12px;
-    border: 1px solid var(--border-color);
-    border-radius: 2px;
-    font-size: 14px;
+    margin-bottom: 8px;
+}
+
+.solution-picker-trigger {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
     background-color: var(--background);
     color: var(--text-color);
-    transition: border-color 0.15s;
+    font-size: 13px;
+    cursor: pointer;
 }
 
-.form-group select:focus,
-.form-group input[type="text"]:focus {
+.solution-picker-trigger:hover:not(:disabled) {
+    border-color: var(--primary-color);
+}
+
+.solution-picker-trigger:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.solution-picker-label {
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+
+.solution-picker-value {
+    flex: 1;
+    text-align: left;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.solution-picker-chevron {
+    color: var(--text-secondary);
+    font-size: 10px;
+}
+
+.solution-picker-popup {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    z-index: 100;
+    width: 100%;
+    background-color: var(--background);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+}
+
+.solution-picker-search {
+    width: 100%;
+    padding: 9px 12px;
+    border: none;
+    border-bottom: 1px solid var(--border-color);
+    background-color: var(--background);
+    color: var(--text-color);
+    font-size: 13px;
+    outline: none;
+}
+
+.solution-picker-options {
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.solution-picker-option {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+
+.solution-picker-option:hover {
+    background-color: var(--surface-hover);
+}
+
+.solution-picker-option.active {
+    background-color: var(--primary-soft);
+}
+
+.solution-option-name {
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+}
+
+.solution-option-detail {
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.solution-picker-empty {
+    padding: 14px;
+    color: var(--text-secondary);
+    text-align: center;
+}
+
+/* ------------------------------------------------------------------ layout */
+.app-body {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+}
+
+.error-banner {
+    padding: 8px 16px;
+    background-color: var(--danger-soft);
+    color: var(--danger-color);
+    border-bottom: 1px solid var(--border-color);
+    font-size: 13px;
+    flex-shrink: 0;
+}
+
+.fatal-error {
+    margin: auto;
+    padding: 24px 32px;
+    background-color: var(--danger-soft);
+    color: var(--danger-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    font-size: 14px;
+    max-width: 480px;
+    text-align: center;
+}
+
+/* ---------------------------------------------------------------- sidebar */
+.left-col {
+    width: 300px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--border-color);
+    background-color: var(--surface);
+    overflow: hidden;
+}
+
+.sidebar {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.sidebar-copy {
+    flex-shrink: 0;
+    max-height: 62%;
+    display: flex;
+    padding: 8px;
+    border-top: 1px solid var(--border-color);
+}
+
+.sidebar-copy .panel {
+    flex: 1;
+    min-width: 0;
+}
+
+.sidebar-header {
+    padding: 12px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.sidebar-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+
+.sidebar-search {
+    width: 100%;
+    padding: 7px 10px;
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    background-color: var(--background);
+    color: var(--text-color);
+    font-size: 13px;
+}
+
+.sidebar-search:focus {
     outline: none;
     border-color: var(--primary-color);
 }
 
-.form-group select:disabled,
-.form-group input[type="text"]:disabled {
+.table-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 6px;
+}
+
+.table-item {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    text-align: left;
+    padding: 7px 10px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-color);
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.table-item:hover {
+    background-color: var(--surface-hover);
+}
+
+.table-item.active {
+    background-color: var(--primary-soft);
+    box-shadow: inset 3px 0 0 var(--primary-color);
+}
+
+.table-item-display {
+    font-weight: 500;
+}
+
+.table-item-logical {
+    font-size: 11px;
+    color: var(--text-secondary);
+    font-family: "Consolas", "Monaco", monospace;
+}
+
+.sidebar-footer {
+    padding: 8px 12px;
+    border-top: 1px solid var(--border-color);
+    font-size: 11px;
+    color: var(--text-secondary);
+    min-height: 30px;
+}
+
+.list-hint {
+    padding: 14px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    text-align: center;
+}
+
+/* -------------------------------------------------------------- main area */
+.main-area {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 14px;
+    gap: 12px;
+}
+
+.empty-state {
+    margin: auto;
+    text-align: center;
+    max-width: 420px;
+    color: var(--text-secondary);
+}
+
+.empty-state-icon {
+    font-size: 42px;
+    color: var(--text-faint);
+    margin-bottom: 12px;
+}
+
+.empty-state h2 {
+    font-size: 17px;
+    color: var(--text-color);
+    margin-bottom: 8px;
+}
+
+.empty-state-steps {
+    display: inline-block;
+    text-align: left;
+    margin: 4px 0 0 18px;
+    font-size: 13px;
+    line-height: 1.7;
+}
+
+.empty-state-steps li {
+    padding-left: 4px;
+}
+
+.table-heading {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.table-heading h2 {
+    font-size: 17px;
+    font-weight: 600;
+}
+
+.table-heading-logical {
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-family: "Consolas", "Monaco", monospace;
+}
+
+.loading-inline {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.work-area {
+    flex: 1;
+    display: grid;
+    grid-template-columns: minmax(240px, 1fr) minmax(240px, 1fr);
+    gap: 12px;
+    overflow: hidden;
+    min-height: 0;
+}
+
+/* ------------------------------------------------------------------ panels */
+.panel {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background-color: var(--background);
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+    min-height: 0;
+}
+
+.panel-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border-color);
     background-color: var(--surface);
+    flex-shrink: 0;
+}
+
+.panel-title {
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.panel-subtitle {
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.panel-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.link-button {
+    border: none;
+    background: none;
+    color: var(--primary-color);
+    font-size: 12px;
+    cursor: pointer;
+    padding: 2px 4px;
+}
+
+.link-button:hover {
+    text-decoration: underline;
+}
+
+.view-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 6px;
+}
+
+.view-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 9px;
+    padding: 7px 9px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.view-item:hover {
+    background-color: var(--surface-hover);
+}
+
+.view-item.checked {
+    background-color: var(--primary-soft);
+}
+
+.view-item input {
+    margin-top: 3px;
+    accent-color: var(--primary-color);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.view-item-body {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 3px;
+    min-width: 0;
+}
+
+.view-item-name {
+    font-size: 13px;
+    font-weight: 500;
+    word-break: break-word;
+}
+
+.lookup-flag {
+    margin-left: 6px;
+    color: var(--warning-color);
+}
+
+/* view type badges */
+.view-badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 1px 7px;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+
+.view-badge-default {
+    background-color: var(--badge-default-bg);
+    color: var(--badge-default-fg);
+}
+.view-badge-public {
+    background-color: var(--badge-public-bg);
+    color: var(--badge-public-fg);
+}
+.view-badge-personal {
+    background-color: var(--badge-personal-bg);
+    color: var(--badge-personal-fg);
+}
+.view-badge-lookup {
+    background-color: var(--badge-lookup-bg);
+    color: var(--badge-lookup-fg);
+}
+.view-badge-quickfind {
+    background-color: var(--badge-quickfind-bg);
+    color: var(--badge-quickfind-fg);
+}
+.view-badge-associated {
+    background-color: var(--badge-associated-bg);
+    color: var(--badge-associated-fg);
+}
+.view-badge-advancedfind {
+    background-color: var(--badge-advancedfind-bg);
+    color: var(--badge-advancedfind-fg);
+}
+.view-badge-other {
+    background-color: var(--badge-other-bg);
+    color: var(--badge-other-fg);
+}
+
+/* -------------------------------------------------------------- copy panel */
+.copy-panel {
+    overflow-y: auto;
+}
+
+.copy-options {
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.option-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 9px;
+    cursor: pointer;
+}
+
+.option-item.disabled {
+    opacity: 0.55;
     cursor: not-allowed;
-    opacity: 0.6;
+}
+
+.option-item input {
+    margin-top: 3px;
+    accent-color: var(--primary-color);
+}
+
+.option-item > span {
+    display: flex;
+    flex-direction: column;
+}
+
+.option-name {
+    font-weight: 500;
+}
+
+.option-detail {
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.filters-note {
+    font-size: 11px;
+    color: var(--text-secondary);
+    background-color: var(--surface);
+    border: 1px dashed var(--border-strong);
+    border-radius: 6px;
+    padding: 7px 9px;
+}
+
+.warning-box {
+    margin: 0 12px 10px;
+    padding: 10px 12px;
+    background-color: var(--warning-soft);
+    border: 1px solid var(--warning-border);
+    border-radius: 6px;
+    color: var(--warning-color);
+    font-size: 12px;
+    flex-shrink: 0;
+}
+
+.warning-box p {
+    margin: 4px 0;
+}
+
+.warning-box ul {
+    margin: 4px 0 0 18px;
+}
+
+.warning-box code {
+    font-family: "Consolas", "Monaco", monospace;
+    background-color: rgba(0, 0, 0, 0.06);
+    padding: 0 4px;
+    border-radius: 3px;
+}
+
+body.dark-theme .warning-box code {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.copy-actions {
+    display: flex;
+    gap: 8px;
+    padding: 4px 12px 10px;
+    flex-shrink: 0;
 }
 
 .btn {
-    padding: 8px 16px;
+    padding: 7px 16px;
     border: none;
-    border-radius: 2px;
-    font-size: 14px;
-    font-weight: 500;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
     cursor: pointer;
-    transition: all 0.15s;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
+    font-family: inherit;
 }
 
 .btn:disabled {
-    opacity: 0.4;
+    opacity: 0.45;
     cursor: not-allowed;
 }
 
 .btn-primary {
     background-color: var(--primary-color);
-    color: white;
+    color: #ffffff;
+    flex: 1;
+}
+
+body.dark-theme .btn-primary {
+    color: #0a1a2a;
 }
 
 .btn-primary:hover:not(:disabled) {
     background-color: var(--primary-hover);
 }
 
-.btn-success {
-    background-color: var(--success-color);
-    color: white;
-}
-
-.btn-success:hover:not(:disabled) {
-    filter: brightness(1.1);
-}
-
 .btn-secondary {
     background-color: transparent;
     color: var(--text-color);
-    border: 1px solid var(--border-color);
+    border: 1px solid var(--border-strong);
 }
 
 .btn-secondary:hover:not(:disabled) {
-    background-color: var(--surface);
+    background-color: var(--surface-hover);
 }
 
-.error {
-    background-color: #fde7e9;
-    border: 1px solid #e1dfdd;
-    color: var(--danger-color);
-    padding: 12px;
-    border-radius: 4px;
-    margin-bottom: 12px;
-    font-size: 14px;
-}
-
-.loading {
-    text-align: center;
-    padding: 40px;
-    font-size: 14px;
-    color: var(--text-secondary);
-}
-
-.views-container {
-    display: flex;
-    gap: 16px;
-    flex: 1;
-    overflow: hidden;
-}
-
-.views-panel {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-}
-
-.panel-header {
-    margin-bottom: 12px;
-}
-
-.panel-title {
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--text-color);
-    margin-bottom: 4px;
-}
-
-.panel-subtitle {
-    font-size: 12px;
-    color: var(--text-secondary);
-}
-
-.view-list {
-    flex: 1;
-    overflow-y: auto;
-    border: 1px solid var(--border-color);
-    border-radius: 2px;
-    background-color: var(--background);
-}
-
-.view-item {
-    padding: 10px 12px;
-    border-bottom: 1px solid var(--border-color);
-    cursor: pointer;
-    transition: background-color 0.15s;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    font-size: 13px;
-}
-
-.view-item:last-child {
-    border-bottom: none;
-}
-
-.view-item:hover {
-    background-color: var(--surface);
-}
-
-.view-item.selected {
-    background-color: var(--primary-color);
-    color: var(--background);
-    border-left: 3px solid var(--primary-hover);
-}
-
-.view-item.source {
-    background-color: var(--secondary-color);
-    color: var(--text-color);
-    border-left: 3px solid var(--success-color);
-}
-
-.view-item input[type="checkbox"],
-.view-item input[type="radio"] {
-    margin: 0;
-    width: 16px;
-    height: 16px;
-    cursor: pointer;
-    flex-shrink: 0;
-}
-
-.layout-preview {
-    background-color: var(--surface);
-    padding: 12px;
-    border-radius: 2px;
-    max-height: 200px;
-    overflow-y: auto;
-    border: 1px solid var(--border-color);
-    margin-top: 12px;
-}
-
-.layout-preview pre {
-    margin: 0;
-    font-family: "Consolas", "Monaco", "Courier New", monospace;
-    font-size: 11px;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    color: var(--text-color);
-}
-
-.button-group {
-    display: flex;
-    gap: 8px;
-    margin-top: 16px;
-}
-
-.action-bar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 12px;
-    background-color: var(--surface);
-    border-top: 1px solid var(--border-color);
-}
-
-.selection-info {
-    font-size: 13px;
-    color: var(--text-secondary);
-}
-
-.selection-info strong {
-    color: var(--text-color);
-}
-
+/* ---------------------------------------------------------------- progress */
 .progress-list {
-    margin-top: 12px;
-    border: 1px solid var(--border-color);
-    border-radius: 2px;
-    background-color: var(--background);
-    max-height: 200px;
+    border-top: 1px solid var(--border-color);
     overflow-y: auto;
 }
 
 .progress-item {
-    padding: 8px 12px;
-    border-bottom: 1px solid var(--border-color);
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 8px;
-    font-size: 13px;
+    padding: 7px 12px;
+    border-bottom: 1px solid var(--border-color);
+    font-size: 12px;
 }
 
 .progress-item:last-child {
     border-bottom: none;
 }
 
-.progress-item.success {
-    background-color: #f3f9f3;
+.progress-item.success .status-icon {
     color: var(--success-color);
 }
 
 .progress-item.error {
-    background-color: #fde7e9;
+    background-color: var(--danger-soft);
+}
+
+.progress-item.error .status-icon {
     color: var(--danger-color);
 }
 
-.progress-item.pending {
+.progress-item.pending .status-icon {
     color: var(--text-secondary);
+}
+
+.progress-item.publish-item {
+    background-color: var(--surface);
+    border-top: 1px dashed var(--border-strong);
+}
+
+.progress-item.publish-item.error {
+    background-color: var(--danger-soft);
 }
 
 .status-icon {
-    font-weight: bold;
-    font-size: 14px;
+    font-weight: 700;
     flex-shrink: 0;
 }
 
-.content-wrapper {
-    flex: 1;
+.progress-body {
     display: flex;
     flex-direction: column;
-    gap: 16px;
-    overflow: hidden;
+    min-width: 0;
 }
 
-.main-section {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
+.progress-name {
+    font-weight: 500;
 }
 
-.compact-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 12px;
-}
-
-.tool-title {
-    font-size: 18px;
-    font-weight: 600;
-    color: var(--text-color);
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.help-text {
+.progress-message {
     color: var(--text-secondary);
+    font-size: 11px;
+}
+
+/* ---------------------------------------------------------- layout preview */
+.layout-preview {
+    flex-shrink: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background-color: var(--background);
+    box-shadow: var(--shadow-sm);
+    padding: 10px 12px;
+}
+
+.layout-preview-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+}
+
+.layout-preview-title {
+    font-size: 13px;
+}
+
+.layout-preview-meta {
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.layout-columns {
+    display: flex;
+    gap: 3px;
+    overflow-x: auto;
+    padding-bottom: 2px;
+}
+
+.layout-column {
+    min-width: 90px;
+    border: 1px solid var(--border-color);
+    border-top: 3px solid var(--primary-color);
+    border-radius: 4px;
+    background-color: var(--surface);
+    padding: 6px 8px;
+    overflow: hidden;
+}
+
+.layout-column.linked {
+    border-top-color: var(--badge-associated-fg);
+}
+
+.layout-column-name {
     font-size: 12px;
-    margin-top: 4px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.layout-column-sort {
+    color: var(--primary-color);
+}
+
+.layout-column-detail {
+    font-size: 10px;
+    color: var(--text-secondary);
+    font-family: "Consolas", "Monaco", monospace;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.preview-error {
+    padding: 10px 12px;
+    background-color: var(--danger-soft);
+    color: var(--danger-color);
+    border-radius: 6px;
+    font-size: 12px;
 }

--- a/tools/view-layout-copier/src/styles.css
+++ b/tools/view-layout-copier/src/styles.css
@@ -182,12 +182,6 @@ body {
     border: 1px solid var(--warning-border);
 }
 
-.tag-managed {
-    background-color: var(--badge-other-bg);
-    color: var(--badge-other-fg);
-    margin-left: 6px;
-}
-
 /* -------------------------------------------------------- solution picker */
 .solution-picker {
     position: relative;

--- a/tools/view-layout-copier/src/styles.css
+++ b/tools/view-layout-copier/src/styles.css
@@ -148,6 +148,12 @@ body {
     white-space: nowrap;
 }
 
+.app-version {
+    font-size: 11px;
+    color: var(--text-faint);
+    white-space: nowrap;
+}
+
 .connection-info {
     margin-left: auto;
     font-size: 12px;

--- a/tools/view-layout-copier/src/styles.css
+++ b/tools/view-layout-copier/src/styles.css
@@ -338,6 +338,47 @@ body {
     overflow: hidden;
 }
 
+.left-tabs {
+    display: flex;
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.left-tab {
+    flex: 1;
+    padding: 9px 10px;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+}
+
+.left-tab:hover {
+    color: var(--text-color);
+    background-color: var(--surface-hover);
+}
+
+.left-tab.active {
+    color: var(--primary-color);
+    border-bottom-color: var(--primary-color);
+}
+
+.left-tab-content {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.left-tab-content[hidden] {
+    display: none;
+}
+
 .sidebar {
     flex: 1;
     min-height: 0;
@@ -362,15 +403,6 @@ body {
 .sidebar-header {
     padding: 12px;
     border-bottom: 1px solid var(--border-color);
-}
-
-.sidebar-title {
-    font-size: 12px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--text-secondary);
-    margin-bottom: 8px;
 }
 
 .sidebar-search {
@@ -658,17 +690,38 @@ body {
     color: var(--badge-other-fg);
 }
 
-/* -------------------------------------------------------------- copy panel */
-.copy-panel {
+/* ------------------------------------------------------ configuration tab */
+.config-panel {
+    flex: 1;
+    min-height: 0;
     overflow-y: auto;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
-.copy-options {
-    padding: 10px 12px;
+.config-section {
     display: flex;
     flex-direction: column;
     gap: 10px;
-    flex-shrink: 0;
+}
+
+.config-section-title {
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.config-section-subtitle {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: -8px;
+}
+
+/* ------------------------------------------------------- copy actions bar */
+.copy-actions-bar {
+    overflow-y: auto;
+    padding-top: 6px;
 }
 
 .option-item {
@@ -712,7 +765,7 @@ body {
 }
 
 .warning-box {
-    margin: 0 12px 10px;
+    margin: 6px 12px 10px;
     padding: 10px 12px;
     background-color: var(--warning-soft);
     border: 1px solid var(--warning-border);

--- a/tools/view-layout-copier/src/utils/DataverseClient.ts
+++ b/tools/view-layout-copier/src/utils/DataverseClient.ts
@@ -16,18 +16,44 @@ export interface ViewUpdatePayload {
 }
 
 export class DataverseClient {
-    /** List visible solutions in the environment, alphabetized by display name */
+    /** List visible, unmanaged solutions (the only ones this tool can write to), alphabetized by display name */
     async listSolutions(): Promise<Solution[]> {
         const entitySetName = await window.dataverseAPI.getEntitySetName("solution");
-        const response = await window.dataverseAPI.queryData(`${entitySetName}?$select=solutionid,friendlyname,uniquename,version,ismanaged&$filter=isvisible eq true&$orderby=friendlyname asc`);
+        const response = await window.dataverseAPI.queryData(
+            `${entitySetName}?$select=solutionid,friendlyname,uniquename,version&$filter=isvisible eq true and ismanaged eq false&$orderby=friendlyname asc`,
+        );
 
         return response.value.map((s: any) => ({
             id: s.solutionid,
             uniqueName: s.uniquename,
             displayName: s.friendlyname,
             version: s.version,
-            isManaged: s.ismanaged === true,
         }));
+    }
+
+    /**
+     * The solution the current user has selected as their default/preferred solution in the
+     * maker portal (usersettings.preferredsolution), if any. Returns null if unset, unavailable,
+     * or the lookup fails for any reason — callers should fall back to their own default.
+     */
+    async getPreferredSolutionId(): Promise<string | null> {
+        try {
+            const who = await window.dataverseAPI.execute({ operationName: "WhoAmI", operationType: "function" });
+            const userId = who.UserId as string | undefined;
+            if (!userId) return null;
+
+            // usersettings' entity set name ("usersettingscollection") doesn't follow normal
+            // pluralization rules, so it's hardcoded here rather than derived.
+            const response = await window.dataverseAPI.queryData(
+                `usersettingscollection?$select=systemuserid&$filter=systemuserid eq ${escapeODataString(userId)}&$expand=preferredsolution($select=solutionid)`,
+            );
+
+            const solutionId = (response.value[0] as any)?.preferredsolution?.solutionid;
+            return typeof solutionId === "string" ? solutionId : null;
+        } catch (error) {
+            console.warn("Could not determine the user's preferred solution:", error);
+            return null;
+        }
     }
 
     /** Get the MetadataIds of the tables contained in a solution */

--- a/tools/view-layout-copier/src/utils/DataverseClient.ts
+++ b/tools/view-layout-copier/src/utils/DataverseClient.ts
@@ -1,87 +1,145 @@
-import { Entity, View } from "../models/interfaces";
+import { Solution, TableInfo, ViewInfo } from "../models/interfaces";
+
+/** Escape OData string literals to prevent query injection */
+function escapeODataString(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
+function extractLabel(value: any): string {
+    return value?.UserLocalizedLabel?.Label || value?.LocalizedLabels?.[0]?.Label || "";
+}
+
+export interface ViewUpdatePayload {
+    fetchxml?: string;
+    layoutxml?: string;
+    layoutjson?: string;
+}
 
 export class DataverseClient {
-    constructor() {
-        // No longer need credentials - using window.dataverseAPI
+    /** List visible solutions in the environment, alphabetized by display name */
+    async listSolutions(): Promise<Solution[]> {
+        const entitySetName = await window.dataverseAPI.getEntitySetName("solution");
+        const response = await window.dataverseAPI.queryData(`${entitySetName}?$select=solutionid,friendlyname,uniquename,version,ismanaged&$filter=isvisible eq true&$orderby=friendlyname asc`);
+
+        return response.value.map((s: any) => ({
+            id: s.solutionid,
+            uniqueName: s.uniquename,
+            displayName: s.friendlyname,
+            version: s.version,
+            isManaged: s.ismanaged === true,
+        }));
     }
 
-    async listEntities(): Promise<Entity[]> {
-        try {
-            // Use getAllEntitiesMetadata from dataverseAPI
-            const response = await window.dataverseAPI.getAllEntitiesMetadata(["LogicalName", "DisplayName", "ObjectTypeCode", "IsValidForAdvancedFind", "IsCustomizable"]);
-
-            // Filter for valid and customizable entities
-            return response.value
-                .filter((entity: any) => entity.IsValidForAdvancedFind === true && entity.IsCustomizable?.Value === true)
-                .map((entity: any) => ({
-                    logicalName: entity.LogicalName,
-                    displayName: entity.DisplayName?.LocalizedLabels?.[0]?.Label || entity.LogicalName,
-                    objectTypeCode: entity.ObjectTypeCode,
-                }))
-                .sort((a, b) => a.logicalName.localeCompare(b.logicalName));
-        } catch (error: any) {
-            console.error("Failed to fetch entities:", error);
-            throw new Error(`Failed to fetch entities: ${error.message}`);
-        }
+    /** Get the MetadataIds of the tables contained in a solution */
+    async listSolutionTableIds(solutionId: string): Promise<Set<string>> {
+        const entitySetName = await window.dataverseAPI.getEntitySetName("solutioncomponent");
+        const response = await window.dataverseAPI.queryData(`${entitySetName}?$select=objectid&$filter=_solutionid_value eq ${escapeODataString(solutionId)} and componenttype eq 1`);
+        return new Set(response.value.map((c: any) => String(c.objectid).toLowerCase()));
     }
 
-    async listViews(entityLogicalName: string): Promise<View[]> {
-        try {
-            // Get entity set name for OData query
-            const entitySetName = await window.dataverseAPI.getEntitySetName("savedquery");
+    /** List all tables usable by this tool, alphabetized by display name */
+    async listTables(): Promise<TableInfo[]> {
+        const response = await window.dataverseAPI.getAllEntitiesMetadata([
+            "LogicalName",
+            "SchemaName",
+            "DisplayName",
+            "ObjectTypeCode",
+            "MetadataId",
+            "PrimaryNameAttribute",
+            "IsValidForAdvancedFind",
+            "IsCustomizable",
+        ]);
 
-            // Use queryData with OData filter for savedqueries
-            const response = await window.dataverseAPI.queryData(
-                `${entitySetName}?$select=savedqueryid,name,fetchxml,layoutxml,returnedtypecode,querytype&$filter=returnedtypecode eq '${entityLogicalName}' and statecode eq 0&$orderby=name`,
-            );
-
-            const views: View[] = response.value.map((view: any) => ({
-                savedqueryid: view.savedqueryid,
-                name: view.name,
-                fetchxml: view.fetchxml,
-                layoutxml: view.layoutxml,
-                returnedtypecode: view.returnedtypecode,
-                querytype: view.querytype,
-            }));
-
-            return views;
-        } catch (error: any) {
-            console.error("Failed to fetch views:", error);
-            throw new Error(`Failed to fetch views: ${error.message}`);
-        }
+        return response.value
+            .filter((e: any) => e.IsValidForAdvancedFind === true && e.IsCustomizable?.Value === true)
+            .map((e: any) => ({
+                logicalName: e.LogicalName,
+                schemaName: e.SchemaName || e.LogicalName,
+                displayName: extractLabel(e.DisplayName) || e.LogicalName,
+                objectTypeCode: e.ObjectTypeCode,
+                metadataId: String(e.MetadataId).toLowerCase(),
+                primaryNameAttribute: e.PrimaryNameAttribute || "name",
+            }))
+            .sort((a: TableInfo, b: TableInfo) => a.displayName.localeCompare(b.displayName, undefined, { sensitivity: "base" }));
     }
 
-    async getView(viewId: string): Promise<View> {
-        try {
-            // Use retrieve to get a specific savedquery
-            const view = await window.dataverseAPI.retrieve("savedquery", viewId, ["savedqueryid", "name", "fetchxml", "layoutxml", "returnedtypecode", "querytype"]);
+    /** List system views (savedquery) and personal views (userquery) for a table */
+    async listViews(tableLogicalName: string): Promise<ViewInfo[]> {
+        const escapedName = escapeODataString(tableLogicalName);
 
-            return {
-                savedqueryid: view.savedqueryid as string,
-                name: view.name as string,
-                fetchxml: view.fetchxml as string,
-                layoutxml: view.layoutxml as string,
-                returnedtypecode: view.returnedtypecode as string,
-                querytype: view.querytype as number,
-            };
-        } catch (error: any) {
-            console.error("Failed to fetch view:", error);
-            throw new Error(`Failed to fetch view: ${error.message}`);
-        }
+        const savedQuerySet = await window.dataverseAPI.getEntitySetName("savedquery");
+        const systemViewsPromise = (async () => {
+            const filter = `$filter=returnedtypecode eq '${escapedName}' and statecode eq 0&$orderby=name asc`;
+            try {
+                return await window.dataverseAPI.queryData(`${savedQuerySet}?$select=savedqueryid,name,description,fetchxml,layoutxml,layoutjson,querytype,isdefault&${filter}`);
+            } catch {
+                // Older environments may not expose layoutjson — retry without it
+                return await window.dataverseAPI.queryData(`${savedQuerySet}?$select=savedqueryid,name,description,fetchxml,layoutxml,querytype,isdefault&${filter}`);
+            }
+        })();
+
+        // Personal views are optional — the user may lack read privileges on userquery
+        const personalViewsPromise = (async () => {
+            try {
+                const userQuerySet = await window.dataverseAPI.getEntitySetName("userquery");
+                return await window.dataverseAPI.queryData(
+                    `${userQuerySet}?$select=userqueryid,name,description,fetchxml,layoutxml,querytype&$filter=returnedtypecode eq '${escapedName}' and statecode eq 0&$orderby=name asc`,
+                );
+            } catch (error) {
+                console.warn("Could not load personal views:", error);
+                return { value: [] };
+            }
+        })();
+
+        const [systemViews, personalViews] = await Promise.all([systemViewsPromise, personalViewsPromise]);
+
+        const views: ViewInfo[] = [
+            ...systemViews.value.map((v: any) => ({
+                id: v.savedqueryid,
+                name: v.name,
+                description: v.description || undefined,
+                fetchxml: v.fetchxml,
+                layoutxml: v.layoutxml,
+                layoutjson: v.layoutjson ?? null,
+                querytype: v.querytype ?? 0,
+                isDefault: v.isdefault === true,
+                isPersonal: false,
+            })),
+            ...personalViews.value.map((v: any) => ({
+                id: v.userqueryid,
+                name: v.name,
+                description: v.description || undefined,
+                fetchxml: v.fetchxml,
+                layoutxml: v.layoutxml,
+                layoutjson: null,
+                querytype: v.querytype ?? 0,
+                isDefault: false,
+                isPersonal: true,
+            })),
+        ];
+
+        // Views without a layout (e.g. some offline templates) can't participate in layout copying
+        return views.filter((v) => !!v.layoutxml);
     }
 
-    async updateViewLayout(entityLogicalName: string, viewId: string, layoutXml: string): Promise<void> {
-        try {
-            // Use update to modify the savedquery's layoutxml
-            await window.dataverseAPI.update("savedquery", viewId, {
-                layoutxml: layoutXml,
-            });
-
-            // Publish the customizations after update
-            await window.dataverseAPI.publishCustomizations(entityLogicalName);
-        } catch (error: any) {
-            console.error("Failed to update view layout:", error);
-            throw new Error(`Failed to update view layout: ${error.message}`);
+    /** Map of attribute logical name -> display name, for the layout preview */
+    async listAttributeDisplayNames(tableLogicalName: string): Promise<Map<string, string>> {
+        const response: any = await window.dataverseAPI.getEntityRelatedMetadata(tableLogicalName, "Attributes", ["LogicalName", "DisplayName"]);
+        const map = new Map<string, string>();
+        for (const attr of response.value ?? []) {
+            map.set(attr.LogicalName, extractLabel(attr.DisplayName) || attr.LogicalName);
         }
+        return map;
+    }
+
+    /** Update a system or personal view with the merged layout/fetch changes */
+    async updateView(view: ViewInfo, payload: ViewUpdatePayload): Promise<void> {
+        const entityName = view.isPersonal ? "userquery" : "savedquery";
+        await window.dataverseAPI.update(entityName, view.id, payload as Record<string, unknown>);
+    }
+
+    /** Publish the table once after all system view updates (personal views don't need publishing) */
+    async publishTable(tableLogicalName: string): Promise<void> {
+        await window.dataverseAPI.publishCustomizations(tableLogicalName);
     }
 }

--- a/tools/view-layout-copier/src/utils/layoutUtils.ts
+++ b/tools/view-layout-copier/src/utils/layoutUtils.ts
@@ -1,0 +1,233 @@
+/**
+ * Pure helpers for parsing and merging view layoutxml / fetchxml.
+ *
+ * Design rules honored here:
+ *  - Filters are NEVER copied between views. Sort order and columns are merged
+ *    into the target fetchxml while leaving every <filter> of the target untouched.
+ *  - Link-entities copied from the source (needed for aliased layout columns)
+ *    have their <filter> and <order> children stripped before insertion.
+ */
+
+export interface LayoutColumn {
+    /** attribute logical name, or "alias.attribute" for linked columns */
+    name: string;
+    width: number;
+    isHidden: boolean;
+}
+
+export interface SortOrder {
+    attribute: string;
+    descending: boolean;
+    /** entityname attribute (link-entity alias) when sorting on a linked column */
+    entityAlias?: string;
+}
+
+export interface FetchMergeResult {
+    fetchXml: string;
+    changed: boolean;
+    addedAttributes: string[];
+    addedLinkEntities: string[];
+    /** orders that could not be applied because their link-entity alias is missing in the target */
+    droppedOrders: string[];
+}
+
+function parseXml(xml: string): Document {
+    const doc = new DOMParser().parseFromString(xml, "text/xml");
+    if (doc.getElementsByTagName("parsererror").length > 0) {
+        throw new Error("Invalid XML");
+    }
+    return doc;
+}
+
+function serializeXml(doc: Document): string {
+    return new XMLSerializer().serializeToString(doc);
+}
+
+function directChildren(parent: Element, tagName: string): Element[] {
+    return Array.from(parent.children).filter((c) => c.tagName === tagName);
+}
+
+function getRootEntity(doc: Document): Element {
+    const fetch = doc.documentElement;
+    const entity = directChildren(fetch, "entity")[0];
+    if (!entity) {
+        throw new Error("fetchxml has no <entity> element");
+    }
+    return entity;
+}
+
+/** Parse the visible/hidden columns of a view's layoutxml, in display order. */
+export function parseLayoutColumns(layoutXml: string): LayoutColumn[] {
+    const doc = parseXml(layoutXml);
+    const cells = Array.from(doc.getElementsByTagName("cell"));
+    return cells.map((cell) => ({
+        name: cell.getAttribute("name") ?? "",
+        width: parseInt(cell.getAttribute("width") ?? "100", 10) || 100,
+        isHidden: cell.getAttribute("ishidden") === "1",
+    }));
+}
+
+/** Parse sort orders from a view's fetchxml (root-entity orders plus orders nested in link-entities). */
+export function parseSortOrders(fetchXml: string): SortOrder[] {
+    const doc = parseXml(fetchXml);
+    const entity = getRootEntity(doc);
+    const orders: SortOrder[] = [];
+
+    for (const order of directChildren(entity, "order")) {
+        orders.push({
+            attribute: order.getAttribute("attribute") ?? "",
+            descending: order.getAttribute("descending") === "true",
+            entityAlias: order.getAttribute("entityname") ?? undefined,
+        });
+    }
+
+    for (const link of Array.from(entity.getElementsByTagName("link-entity"))) {
+        for (const order of directChildren(link, "order")) {
+            orders.push({
+                attribute: order.getAttribute("attribute") ?? "",
+                descending: order.getAttribute("descending") === "true",
+                entityAlias: link.getAttribute("alias") ?? undefined,
+            });
+        }
+    }
+
+    return orders;
+}
+
+/**
+ * Build the target's new layoutxml: the source grid's rows (the column definitions)
+ * replace the target's, while the target keeps its own <grid> attributes
+ * (jump, select, icon, preview, ...) which differ between view types.
+ */
+export function buildTargetLayoutXml(sourceLayoutXml: string, targetLayoutXml: string): string {
+    const sourceDoc = parseXml(sourceLayoutXml);
+    const targetDoc = parseXml(targetLayoutXml);
+
+    const sourceGrid = sourceDoc.getElementsByTagName("grid")[0];
+    const targetGrid = targetDoc.getElementsByTagName("grid")[0];
+    if (!sourceGrid || !targetGrid) {
+        throw new Error("layoutxml has no <grid> element");
+    }
+
+    for (const row of directChildren(targetGrid, "row")) {
+        targetGrid.removeChild(row);
+    }
+    for (const row of directChildren(sourceGrid, "row")) {
+        targetGrid.appendChild(targetDoc.importNode(row, true));
+    }
+
+    return serializeXml(targetDoc);
+}
+
+function findLinkEntityByAlias(scope: Element, alias: string): Element | undefined {
+    return Array.from(scope.getElementsByTagName("link-entity")).find((le) => le.getAttribute("alias") === alias);
+}
+
+function ensureAttribute(doc: Document, parent: Element, name: string, added: string[], addedLabel: string): void {
+    const exists = directChildren(parent, "attribute").some((a) => a.getAttribute("name") === name);
+    const isAllAttributes = directChildren(parent, "all-attributes").length > 0;
+    if (exists || isAllAttributes) {
+        return;
+    }
+    const attr = doc.createElement("attribute");
+    attr.setAttribute("name", name);
+    parent.insertBefore(attr, parent.firstChild);
+    added.push(addedLabel);
+}
+
+/**
+ * Merge the pieces of the source fetchxml that the copied layout needs into the
+ * target fetchxml, without ever touching the target's filters.
+ *
+ * - requiredColumns: layout cell names; missing <attribute> nodes (and missing
+ *   link-entities for aliased columns) are added. Link-entities cloned from the
+ *   source are stripped of their <filter>/<order> children.
+ * - copySortOrder: target's <order> elements are replaced with the source's.
+ */
+export function mergeFetchXml(sourceFetchXml: string, targetFetchXml: string, requiredColumns: string[], copySortOrder: boolean): FetchMergeResult {
+    const sourceDoc = parseXml(sourceFetchXml);
+    const targetDoc = parseXml(targetFetchXml);
+    const sourceEntity = getRootEntity(sourceDoc);
+    const targetEntity = getRootEntity(targetDoc);
+
+    const addedAttributes: string[] = [];
+    const addedLinkEntities: string[] = [];
+    const droppedOrders: string[] = [];
+
+    for (const column of requiredColumns) {
+        if (!column) continue;
+
+        const dotIndex = column.indexOf(".");
+        if (dotIndex === -1) {
+            ensureAttribute(targetDoc, targetEntity, column, addedAttributes, column);
+            continue;
+        }
+
+        // Aliased column from a link-entity, e.g. "primarycontact.emailaddress1"
+        const alias = column.substring(0, dotIndex);
+        const attribute = column.substring(dotIndex + 1);
+
+        let targetLink = findLinkEntityByAlias(targetEntity, alias);
+        if (!targetLink) {
+            const sourceLink = findLinkEntityByAlias(sourceEntity, alias);
+            if (!sourceLink) {
+                // Source layout references an alias its own fetchxml doesn't define; nothing we can do.
+                continue;
+            }
+            const clone = targetDoc.importNode(sourceLink, true) as Element;
+            // Filters are intentionally not copied between views; orders are handled separately.
+            for (const tag of ["filter", "order"]) {
+                for (const el of Array.from(clone.getElementsByTagName(tag))) {
+                    el.parentNode?.removeChild(el);
+                }
+            }
+            targetEntity.appendChild(clone);
+            targetLink = clone;
+            addedLinkEntities.push(alias);
+        }
+        ensureAttribute(targetDoc, targetLink, attribute, addedAttributes, column);
+    }
+
+    if (copySortOrder) {
+        // Remove every existing order in the target (root entity and link-entities)
+        for (const order of directChildren(targetEntity, "order")) {
+            targetEntity.removeChild(order);
+        }
+        for (const link of Array.from(targetEntity.getElementsByTagName("link-entity"))) {
+            for (const order of directChildren(link, "order")) {
+                link.removeChild(order);
+            }
+        }
+
+        // Copy root-entity orders from the source
+        for (const order of directChildren(sourceEntity, "order")) {
+            const entityAlias = order.getAttribute("entityname");
+            if (entityAlias && !findLinkEntityByAlias(targetEntity, entityAlias)) {
+                droppedOrders.push(`${entityAlias}.${order.getAttribute("attribute") ?? ""}`);
+                continue;
+            }
+            targetEntity.appendChild(targetDoc.importNode(order, true));
+        }
+
+        // Copy orders nested inside source link-entities into the matching target link-entity
+        for (const link of Array.from(sourceEntity.getElementsByTagName("link-entity"))) {
+            const alias = link.getAttribute("alias");
+            for (const order of directChildren(link, "order")) {
+                const targetLink = alias ? findLinkEntityByAlias(targetEntity, alias) : undefined;
+                if (targetLink) {
+                    targetLink.appendChild(targetDoc.importNode(order, true));
+                } else {
+                    droppedOrders.push(`${alias ?? "?"}.${order.getAttribute("attribute") ?? ""}`);
+                }
+            }
+        }
+    }
+
+    return {
+        fetchXml: serializeXml(targetDoc),
+        changed: copySortOrder || addedAttributes.length > 0 || addedLinkEntities.length > 0,
+        addedAttributes,
+        addedLinkEntities,
+        droppedOrders,
+    };
+}

--- a/tools/view-layout-copier/src/vite-env.d.ts
+++ b/tools/view-layout-copier/src/vite-env.d.ts
@@ -1,10 +1,11 @@
+/// <reference types="vite/client" />
 /// <reference types="@pptb/types" />
 
 declare global {
     interface Window {
-        toolboxAPI: typeof import('@pptb/types').toolboxAPI;
-        dataverseAPI: typeof import('@pptb/types').dataverseAPI;
+        toolboxAPI: typeof import("@pptb/types").toolboxAPI;
+        dataverseAPI: typeof import("@pptb/types").dataverseAPI;
     }
 }
 
-export { };
+export {};


### PR DESCRIPTION
## Summary

A rework of the **View Layout Copier** tool focused on usability and copy fidelity, inspired by the XrmToolBox View Layout Replicator workflow.

### What's new

- **Solution selector on launch** — narrow the table list to a solution (managed solutions tagged), or work across all tables
- **Persistent, searchable table sidebar** — search by display name *or* schema/logical name; alphabetized by display name; stays available while working
- **View type badges** — Default Public View, Public View, Personal View, Associated View, Advanced Find View, Quick Find View, Lookup View, etc.
- **Personal view support** — userquery views are listed and can be copy sources/targets (no publish needed for them)
- **Source layout preview** — columns in order with relative widths, display names, and sort indicators, shown above the view panes
- **Selective copying** (all on by default): column layout, sort order, components configuration (`layoutjson`)
- **Filters are never copied** — each target keeps its own filter criteria (noted in the UI)
- **Smart fetchxml merging** — attributes referenced by the copied layout are added to the target query automatically; link-entities needed for aliased columns are carried over *without* their filters; the previous version copied `layoutxml` without this, which could produce views whose layout referenced columns the query didn't fetch
- **Lookup view warning** — when a lookup view is a target and the source layout's first column isn't the table's primary name attribute
- **Single publish per operation** (previously one publish per target view) with a visible publish status row
- **Demo mode for development** — `npm run dev` outside PPTB installs an in-memory mock of `dataverseAPI`/`toolboxAPI` with sample data so the whole flow can be exercised in a plain browser; production builds are unaffected and still require PPTB

### Notes

- Version bumped to 1.1.0; `npm-shrinkwrap.json` regenerated
- Added the `icon` field to package.json to match the other tools
- No new runtime dependencies (plain React + hand-rolled CSS, light/dark theme via the existing `body.dark-theme` convention)
- `tsc --noEmit` and `vite build` are clean

### Testing

- Exercised end-to-end in demo mode: solution filtering, search by display/schema name, source/target selection, all copy option combinations, lookup warning on/off, copy + publish progress
- Verified merged XML output: target filters preserved, source sort replaces target sort, missing attributes/link-entities added, `layoutjson` copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)