### PR TITLE
Security Role Comparator v2.0.0: categorized grouping, combined permission, richer diffs, and filters

### DIFF
--- a/tools/security-role-comparator/README.md
+++ b/tools/security-role-comparator/README.md
@@ -5,26 +5,29 @@ A [PPTB](https://github.com/Power-Maverick/PowerPlatformToolBox) tool that lets 
 ## Features
 
 - **Side-by-side comparison** – Select a base role and up to 5 comparison roles
-- **Solution-scoped role selection** – Pick a solution first, with unmanaged solutions listed before managed solutions
-- **Grouped role lists** – Roles are grouped into unmanaged and managed sections, with origin labels to help distinguish custom vs. template/system roles
-- **Remembered selections** – Last-used solution and role picks are restored per environment in the browser
-- **Entity display + schema names** – Entity rows now show both names, and search matches either one
+- **Grouped role lists** – Roles are grouped into Unmanaged and Managed sections; same-named roles are disambiguated by business unit
+- **Remembered selections** – Last-used base and comparison role picks are restored per environment in the browser
+- **Entity display + schema names** – Entity rows show both names, and search matches either one
 - **Category grouping** – Privileges are grouped like the OOB role editor (Tables tabs such as Core Records, Business Management, Customization, Custom Entities, Business Process Flows), plus separate Miscellaneous and Privacy-related sections, sourced from the `roleeditorlayout` table
-- **Depth visualization** – Four filled/empty dots represent None → User → Business Unit → Parent-Child BU → Organization
+- **Depth visualization** – Each privilege depth is shown with an icon mirroring the Dataverse security-role editor (None, User, Business Unit, Parent-Child BU, Organization)
 - **Directional difference icons** – A green **＋** marks a compared role with *more* permission than the base for a privilege, and a red **－** marks *less*
-- **Row filter** – Choose Differences only (default), More than base, Less than base, Same as base, or Show all
+- **Row filter** – Choose All differences (default), More than base, Less than base, Same as base, or Show all
+- **Group & operation filters** – Multi-select dropdowns (each with an *All* shortcut to select/clear everything) to focus on specific groups (Core Records, Business Management, …) and operations (Create, Read, Write, Delete, Append, Append To, Assign, Share, and Enable for non-table privileges)
 - **Entity search** – Filter by entity display name, schema name, or operation (Create, Read, Write, Delete, …)
 - **Dark mode** – Follows the PPTB host theme automatically
 
 ## Privilege Depth Legend
 
-| Dots | Level | Description |
+Each depth level is represented with a Fluent icon that mirrors the built-in Dataverse
+security-role editor:
+
+| Icon | Level | Description |
 |------|-------|-------------|
-| ○○○○ | None | Privilege not granted |
-| ●○○○ | User | Basic (own records) |
-| ●●○○ | Business Unit | Local (business unit records) |
-| ●●●○ | Parent-Child BU | Deep (business unit + child BU records) |
-| ●●●● | Organization | Global (all records) |
+| 🚫 Prohibited | None | Privilege not granted |
+| 👤 Person | User | Basic (own records) |
+| 👥 People | Business Unit | Local (business unit records) |
+| 👨‍👩‍👧 People team | Parent-Child BU | Deep (business unit + child BU records) |
+| 🏢 Organization | Organization | Global (all records) |
 
 Difference icons compare each non-base role's depth against the base role for the same
 privilege: a green plus means more permission, a red minus means less.
@@ -33,7 +36,6 @@ privilege: a green plus means more permission, a red minus means less.
 
 1. Connect to a Dataverse environment in PPTB.
 2. Open **Security Role Comparator**.
-3. Select a **Solution** from the first dropdown.
-4. Select the **Base Role** and one or more **Compare** roles (up to 5 total).
-5. Click **Compare**.
-6. Use the search box or the row filter dropdown to focus on specific areas.
+3. Select the **Base Role** and one or more **Compare** roles (up to 5 total).
+4. Click **Compare**.
+5. Use the search box, group/operation filters, or the row filter dropdown to focus on specific areas.

--- a/tools/security-role-comparator/README.md
+++ b/tools/security-role-comparator/README.md
@@ -5,10 +5,15 @@ A [PPTB](https://github.com/Power-Maverick/PowerPlatformToolBox) tool that lets 
 ## Features
 
 - **Side-by-side comparison** – Select a base role and up to 5 comparison roles
+- **Solution-scoped role selection** – Pick a solution first, with unmanaged solutions listed before managed solutions
+- **Grouped role lists** – Roles are grouped into unmanaged and managed sections, with origin labels to help distinguish custom vs. template/system roles
+- **Remembered selections** – Last-used solution and role picks are restored per environment in the browser
+- **Entity display + schema names** – Entity rows now show both names, and search matches either one
+- **Category grouping** – Privileges are grouped like the OOB role editor (Tables tabs such as Core Records, Business Management, Customization, Custom Entities, Business Process Flows), plus separate Miscellaneous and Privacy-related sections, sourced from the `roleeditorlayout` table
 - **Depth visualization** – Four filled/empty dots represent None → User → Business Unit → Parent-Child BU → Organization
-- **Difference highlighting** – Cells that differ from the base role are highlighted in amber
-- **"Differences only" filter** – Hide rows where all compared roles share the same privilege depth
-- **Entity search** – Filter by entity name or operation (Create, Read, Write, Delete, …)
+- **Directional difference icons** – A green **＋** marks a compared role with *more* permission than the base for a privilege, and a red **－** marks *less*
+- **Row filter** – Choose Differences only (default), More than base, Less than base, Same as base, or Show all
+- **Entity search** – Filter by entity display name, schema name, or operation (Create, Read, Write, Delete, …)
 - **Dark mode** – Follows the PPTB host theme automatically
 
 ## Privilege Depth Legend
@@ -21,11 +26,14 @@ A [PPTB](https://github.com/Power-Maverick/PowerPlatformToolBox) tool that lets 
 | ●●●○ | Parent-Child BU | Deep (business unit + child BU records) |
 | ●●●● | Organization | Global (all records) |
 
+Difference icons compare each non-base role's depth against the base role for the same
+privilege: a green plus means more permission, a red minus means less.
+
 ## Usage
 
 1. Connect to a Dataverse environment in PPTB.
 2. Open **Security Role Comparator**.
-3. Select the **Base Role** from the first dropdown.
-4. Choose one or more **Compare** roles (up to 5 total).
+3. Select a **Solution** from the first dropdown.
+4. Select the **Base Role** and one or more **Compare** roles (up to 5 total).
 5. Click **Compare**.
-6. Use the search box or *Differences only* checkbox to focus on specific areas.
+6. Use the search box or the row filter dropdown to focus on specific areas.

--- a/tools/security-role-comparator/README.md
+++ b/tools/security-role-comparator/README.md
@@ -1,20 +1,43 @@
 # Security Role Comparator
 
-A [PPTB](https://github.com/Power-Maverick/PowerPlatformToolBox) tool that lets you compare one security role against up to **5** other roles in the same Dataverse environment—side by side, privilege by privilege.
+A [PPTB](https://github.com/Power-Maverick/PowerPlatformToolBox) tool that lets you compare one security role against up to **5** other roles in the same Dataverse environment—side by side, privilege by privilege—and see the **combined** permission a user would have if granted all of them.
 
 ## Features
 
-- **Side-by-side comparison** – Select a base role and up to 5 comparison roles
-- **Grouped role lists** – Roles are grouped into Unmanaged and Managed sections; same-named roles are disambiguated by business unit
-- **Remembered selections** – Last-used base and comparison role picks are restored per environment in the browser
-- **Entity display + schema names** – Entity rows show both names, and search matches either one
-- **Category grouping** – Privileges are grouped like the OOB role editor (Tables tabs such as Core Records, Business Management, Customization, Custom Entities, Business Process Flows), plus separate Miscellaneous and Privacy-related sections, sourced from the `roleeditorlayout` table
-- **Depth visualization** – Each privilege depth is shown with an icon mirroring the Dataverse security-role editor (None, User, Business Unit, Parent-Child BU, Organization)
-- **Directional difference icons** – A green **＋** marks a compared role with *more* permission than the base for a privilege, and a red **－** marks *less*
-- **Row filter** – Choose All differences (default), More than base, Less than base, Same as base, or Show all
-- **Group & operation filters** – Multi-select dropdowns (each with an *All* shortcut to select/clear everything) to focus on specific groups (Core Records, Business Management, …) and operations (Create, Read, Write, Delete, Append, Append To, Assign, Share, and Enable for non-table privileges)
-- **Entity search** – Filter by entity display name, schema name, or operation (Create, Read, Write, Delete, …)
-- **Dark mode** – Follows the PPTB host theme automatically
+### Role selection
+- **Side-by-side comparison** – Pick a base role and up to 5 comparison roles.
+- **Grouped role lists** – Roles are grouped into **Unmanaged** and **Managed** sections; roles that share a name are disambiguated by business unit.
+- **Set as Base** – Each comparison column has a **(Set as Base)** link that swaps that role with the base role and re-runs the comparison in place.
+- **Remembered selections** – Your last-used base and comparison roles are restored per environment.
+
+### Privilege grid
+- **Category grouping** – Privileges are grouped like the built-in security role editor: **Tables** tabs (Core Records, Business Management, Customization, Custom Entities, Business Process Flows, …) plus separate **Miscellaneous** and **Privacy Related** sections, sourced from the `roleeditorlayout` table.
+- **Entity display + schema names** – Table rows show both the entity display name and its schema name.
+- **Accurate privilege mapping** – Privileges are mapped to their table and operation from table metadata (`EntityDefinitions.Privileges`), so tables whose privilege names don't match their logical name (for example **SystemUser** and **Activity**) and `AppendTo` privileges are categorized correctly.
+- **Depth icons** – Each privilege depth is shown with an icon that mirrors the Dataverse security-role editor (None, User, Business Unit, Parent-Child BU, Organization).
+- **Directional difference icons** – In each comparison column, a green **＋** marks *more* permission than the base for that privilege and a red **－** marks *less*; cells that match the base are de-emphasized so real differences stand out.
+
+### Filtering
+- **Row filter** – All differences (default), More than base, Less than base, Same as base, Show all, or **Combined Permission** (see below).
+- **Group & Operation filters** – Multi-select dropdowns, each with an **All** shortcut, to focus on specific groups (Core Records, Business Management, …) and operations. Operations follow the canonical order **Create, Read, Write, Delete, Append, Append To, Assign, Share** (with **Enable** used for non-table privileges).
+- **Search** – Matches entity display name, schema name, operation, or the raw privilege name.
+- **Dark mode** – Follows the PPTB host theme automatically.
+
+## Combined Permission
+
+Selecting **Combined Permission** from the row-filter dropdown answers a common question:
+
+> *If a user were assigned the base role **and** every comparison role, what could they actually do?*
+
+When enabled:
+
+- A virtual **Combined Permission** column is appended to the right of the comparison columns (shown with a subtle green tint to indicate it is derived, not a real role).
+- For every privilege, the combined value is the **highest permission granted by any** of the selected roles (base + all comparisons). This reflects how Dataverse security is additive — a user's effective access for a privilege is the broadest scope any of their roles grants.
+- The grid is filtered to only the privileges whose combined permission is **above None** (i.e. the privileges the user would actually hold), still honoring any active **Group** and **Operation** filters.
+
+Depth precedence used for the combination (lowest to highest):
+
+**None → User → Business Unit → Parent-Child Business Unit → Organization**
 
 ## Privilege Depth Legend
 
@@ -38,4 +61,5 @@ privilege: a green plus means more permission, a red minus means less.
 2. Open **Security Role Comparator**.
 3. Select the **Base Role** and one or more **Compare** roles (up to 5 total).
 4. Click **Compare**.
-5. Use the search box, group/operation filters, or the row filter dropdown to focus on specific areas.
+5. Use the search box, the **Group**/**Operation** filters, or the row-filter dropdown to focus on specific areas.
+6. Choose **Combined Permission** in the row-filter dropdown to see the net effective permission across all selected roles.

--- a/tools/security-role-comparator/npm-shrinkwrap.json
+++ b/tools/security-role-comparator/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "@power-maverick/tool-security-role-comparator",
-    "version": "0.0.1",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@power-maverick/tool-security-role-comparator",
-            "version": "0.0.1",
+            "version": "2.0.0",
             "license": "GPL-2.0",
             "dependencies": {
                 "@fluentui/react-components": "^9.56.2",

--- a/tools/security-role-comparator/package.json
+++ b/tools/security-role-comparator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@power-maverick/tool-security-role-comparator",
     "displayName": "Security Role Comparator",
-    "version": "0.0.1",
+    "version": "2.0.0",
     "description": "Compare one security role against up to 5 other roles in the same Dataverse environment",
     "icon": "icons/securityRoleComparator.svg",
     "contributors": [

--- a/tools/security-role-comparator/src/App.tsx
+++ b/tools/security-role-comparator/src/App.tsx
@@ -152,11 +152,11 @@ function normalizeSelections(preferredIds: string[], validIds: Set<string>, disa
 }
 
 /** Renders the Fluent icon representing a privilege depth level. */
-function DepthIcon({ depth }: { depth: PrivilegeDepth }) {
+function DepthIcon({ depth, muted }: { depth: PrivilegeDepth; muted?: boolean }) {
     const { Icon, color } = DEPTH_ICON[depth] ?? DEPTH_ICON[PrivilegeDepth.None];
     return (
         <Tooltip content={DEPTH_LABELS[depth]} relationship="label">
-            <Icon className="depth-icon" style={{ color }} aria-label={DEPTH_LABELS[depth]} />
+            <Icon className={`depth-icon${muted ? " depth-icon-muted" : ""}`} style={{ color }} aria-label={DEPTH_LABELS[depth]} />
         </Tooltip>
     );
 }
@@ -508,40 +508,6 @@ export default function App() {
                         size="small"
                         className="search-box"
                     />
-                    <Dropdown
-                        className="multi-filter"
-                        size="small"
-                        multiselect
-                        placeholder="Groups"
-                        selectedOptions={selectedCategories}
-                        value={multiSelectSummary(selectedCategories, availableCategories, "groups")}
-                        onOptionSelect={(_e, data) => setSelectedCategories((prev) => toggleMultiSelect(data.optionValue ?? "", prev, availableCategories))}
-                        aria-label="Filter by group"
-                    >
-                        <Option value={ALL_VALUE}>All groups</Option>
-                        {availableCategories.map((label) => (
-                            <Option key={label} value={label}>
-                                {label}
-                            </Option>
-                        ))}
-                    </Dropdown>
-                    <Dropdown
-                        className="multi-filter"
-                        size="small"
-                        multiselect
-                        placeholder="Operations"
-                        selectedOptions={selectedOperations}
-                        value={multiSelectSummary(selectedOperations, availableOperations, "operations")}
-                        onOptionSelect={(_e, data) => setSelectedOperations((prev) => toggleMultiSelect(data.optionValue ?? "", prev, availableOperations))}
-                        aria-label="Filter by operation"
-                    >
-                        <Option value={ALL_VALUE}>All operations</Option>
-                        {availableOperations.map((op) => (
-                            <Option key={op} value={op}>
-                                {operationLabel(op)}
-                            </Option>
-                        ))}
-                    </Dropdown>
                     <select
                         className="diff-filter-select"
                         value={diffFilter}
@@ -554,6 +520,46 @@ export default function App() {
                             </option>
                         ))}
                     </select>
+                    <Dropdown
+                        className="multi-filter"
+                        size="small"
+                        multiselect
+                        placeholder="Groups"
+                        listbox={{ className: "filter-listbox" }}
+                        selectedOptions={selectedCategories}
+                        value={multiSelectSummary(selectedCategories, availableCategories, "groups")}
+                        onOptionSelect={(_e, data) => setSelectedCategories((prev) => toggleMultiSelect(data.optionValue ?? "", prev, availableCategories))}
+                        aria-label="Filter by group"
+                    >
+                        <Option className="filter-option" value={ALL_VALUE}>
+                            All groups
+                        </Option>
+                        {availableCategories.map((label) => (
+                            <Option className="filter-option" key={label} value={label}>
+                                {label}
+                            </Option>
+                        ))}
+                    </Dropdown>
+                    <Dropdown
+                        className="multi-filter"
+                        size="small"
+                        multiselect
+                        placeholder="Operations"
+                        listbox={{ className: "filter-listbox" }}
+                        selectedOptions={selectedOperations}
+                        value={multiSelectSummary(selectedOperations, availableOperations, "operations")}
+                        onOptionSelect={(_e, data) => setSelectedOperations((prev) => toggleMultiSelect(data.optionValue ?? "", prev, availableOperations))}
+                        aria-label="Filter by operation"
+                    >
+                        <Option className="filter-option" value={ALL_VALUE}>
+                            All operations
+                        </Option>
+                        {availableOperations.map((op) => (
+                            <Option className="filter-option" key={op} value={op}>
+                                {operationLabel(op)}
+                            </Option>
+                        ))}
+                    </Dropdown>
                     <span className="result-count">
                         {filteredData.length} / {comparisonData.length} privileges
                     </span>
@@ -619,7 +625,7 @@ export default function App() {
                                                                     <SubtractCircleFilled className="diff-icon diff-less" aria-label="Less permission than base" />
                                                                 </Tooltip>
                                                             )}
-                                                            <DepthIcon depth={depth} />
+                                                            <DepthIcon depth={depth} muted={ci > 0 && direction === "none"} />
                                                         </td>
                                                     );
                                                 })}

--- a/tools/security-role-comparator/src/App.tsx
+++ b/tools/security-role-comparator/src/App.tsx
@@ -60,7 +60,7 @@ function multiSelectSummary(selected: string[], available: string[], noun: strin
 }
 
 /** Row-level filter modes for the comparison grid. */
-type DiffFilter = "differences" | "more" | "less" | "same" | "all";
+type DiffFilter = "differences" | "more" | "less" | "same" | "all" | "combined";
 
 const DIFF_FILTER_OPTIONS: { value: DiffFilter; label: string }[] = [
     { value: "differences", label: "All differences" },
@@ -68,6 +68,7 @@ const DIFF_FILTER_OPTIONS: { value: DiffFilter; label: string }[] = [
     { value: "less", label: "Less than base" },
     { value: "same", label: "Same as base" },
     { value: "all", label: "Show all" },
+    { value: "combined", label: "Combined Permission" },
 ];
 
 type DepthIconInfo = { Icon: ComponentType<{ className?: string; style?: CSSProperties; "aria-label"?: string }>; color: string };
@@ -312,8 +313,27 @@ export default function App() {
         return { hasMore, hasLess };
     };
 
+    // Net permission if the user were assigned the base plus all comparison roles: the highest
+    // depth granted by any of them for the privilege.
+    const getCombinedDepth = (priv: ParsedPrivilege): PrivilegeDepth => {
+        let best: PrivilegeDepth = PrivilegeDepth.None;
+        let bestRank = 0;
+        for (const rid of comparedRoleIds) {
+            const depth = priv.depthByRole[rid] ?? PrivilegeDepth.None;
+            const rank = depthRank(depth);
+            if (rank > bestRank) {
+                bestRank = rank;
+                best = depth;
+            }
+        }
+        return best;
+    };
+
+    const showCombined = diffFilter === "combined";
+
     const matchesDiffFilter = (priv: ParsedPrivilege) => {
         if (diffFilter === "all") return true;
+        if (diffFilter === "combined") return depthRank(getCombinedDepth(priv)) > 0;
         const { hasMore, hasLess } = getRowDiff(priv);
         switch (diffFilter) {
             case "differences":
@@ -389,7 +409,7 @@ export default function App() {
         }));
     }, [filteredData]);
 
-    const columnCount = 2 + comparedRoleIds.length;
+    const columnCount = 2 + comparedRoleIds.length + (showCombined ? 1 : 0);
     const hasResults = comparisonData.length > 0;
 
 
@@ -582,6 +602,11 @@ export default function App() {
                                         <span className="role-col-name">{getRoleName(rid)}</span>
                                     </th>
                                 ))}
+                                {showCombined && (
+                                    <th className="col-role col-combined" title="Combined permission of the base and all comparison roles">
+                                        <span className="role-col-name">Combined Permission</span>
+                                    </th>
+                                )}
                             </tr>
                         </thead>
                         <tbody>
@@ -629,6 +654,11 @@ export default function App() {
                                                         </td>
                                                     );
                                                 })}
+                                                {showCombined && (
+                                                    <td className="col-role-cell col-combined-cell">
+                                                        <DepthIcon depth={getCombinedDepth(priv)} />
+                                                    </td>
+                                                )}
                                             </tr>
                                         </Fragment>
                                     ));

--- a/tools/security-role-comparator/src/App.tsx
+++ b/tools/security-role-comparator/src/App.tsx
@@ -1,12 +1,63 @@
-import { Badge, Button, MessageBar, MessageBarBody, SearchBox, Spinner, Tooltip } from "@fluentui/react-components";
-import { AddCircleFilled, ArrowSyncRegular, DismissCircleRegular, SubtractCircleFilled } from "@fluentui/react-icons";
-import { useEffect, useMemo, useRef, useState, Fragment } from "react";
-import { DataverseSolution, DEPTH_LABELS, depthRank, ParsedPrivilege, PrivilegeDepth, SecurityRole } from "./models/interfaces";
+import { Button, Dropdown, MessageBar, MessageBarBody, Option, SearchBox, Spinner, Tooltip } from "@fluentui/react-components";
+import {
+    AddCircleFilled,
+    ArrowSyncRegular,
+    DismissCircleRegular,
+    OrganizationRegular,
+    PeopleRegular,
+    PeopleTeamRegular,
+    PersonRegular,
+    ProhibitedRegular,
+    SubtractCircleFilled,
+} from "@fluentui/react-icons";
+import { ComponentType, CSSProperties, Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { DEPTH_LABELS, depthRank, NON_TABLE_OPERATION, ParsedPrivilege, PrivilegeDepth, SecurityRole } from "./models/interfaces";
 import "./styles.css";
 import { DataverseConnector } from "./utils/dataverseClient";
 
 const MAX_COMPARE_ROLES = 5;
 const STORAGE_PREFIX = "security-role-comparator:recent-selections:v1";
+
+/** Ordered list of operation values used by the operation filter (incl. the non-table placeholder). */
+const OPERATION_ORDER = ["Create", "Read", "Write", "Delete", "Append", "AppendTo", "Assign", "Share", NON_TABLE_OPERATION];
+
+/** Friendlier labels for operation values (others display as-is). */
+const OPERATION_LABELS: Record<string, string> = { AppendTo: "Append To" };
+const operationLabel = (op: string) => OPERATION_LABELS[op] ?? op;
+
+/** Sentinel value for the "All" shortcut option in the multi-select filters. */
+const ALL_VALUE = "__all__";
+
+/**
+ * Computes the next multi-select state when an option is toggled, with an "All" shortcut.
+ * State is either [ALL_VALUE] (everything), a concrete subset (in `available` order), or [] (none).
+ * - Clicking "All" selects everything, or clears everything if already in "all" mode.
+ * - Clicking an individual option while in "all" mode starts a fresh selection of just that option.
+ * - Otherwise the individual option is toggled in/out of the current subset.
+ */
+function toggleMultiSelect(optionValue: string, current: string[], available: string[]): string[] {
+    const allMode = current.includes(ALL_VALUE);
+    if (optionValue === ALL_VALUE) {
+        return allMode ? [] : [ALL_VALUE];
+    }
+    if (allMode) {
+        return [optionValue];
+    }
+    const set = new Set(current);
+    if (set.has(optionValue)) set.delete(optionValue);
+    else set.add(optionValue);
+    return available.filter((value) => set.has(value));
+}
+
+/** True when a value passes a multi-select filter ("all" mode passes everything). */
+const passesMultiSelect = (value: string, selected: string[]) => selected.includes(ALL_VALUE) || selected.includes(value);
+
+/** Summary text shown in the multi-select filter's closed state. */
+function multiSelectSummary(selected: string[], available: string[], noun: string): string {
+    if (selected.includes(ALL_VALUE)) return `All ${noun}`;
+    if (selected.length === 0) return `No ${noun}`;
+    return `${selected.length} of ${available.length} ${noun}`;
+}
 
 /** Row-level filter modes for the comparison grid. */
 type DiffFilter = "differences" | "more" | "less" | "same" | "all";
@@ -19,26 +70,23 @@ const DIFF_FILTER_OPTIONS: { value: DiffFilter; label: string }[] = [
     { value: "all", label: "Show all" },
 ];
 
-const DEPTH_COLORS: Record<PrivilegeDepth, string> = {
-    [PrivilegeDepth.None]: "var(--depth-none)",
-    [PrivilegeDepth.Basic]: "var(--depth-basic)",
-    [PrivilegeDepth.Local]: "var(--depth-local)",
-    [PrivilegeDepth.Deep]: "var(--depth-deep)",
-    [PrivilegeDepth.Global]: "var(--depth-global)",
-};
+type DepthIconInfo = { Icon: ComponentType<{ className?: string; style?: CSSProperties; "aria-label"?: string }>; color: string };
 
-/** Maps a PrivilegeDepth value to the number of filled dots (0–4). */
-const DEPTH_FILLED_COUNT: Record<PrivilegeDepth, number> = {
-    [PrivilegeDepth.None]: 0,
-    [PrivilegeDepth.Basic]: 1,
-    [PrivilegeDepth.Local]: 2,
-    [PrivilegeDepth.Deep]: 3,
-    [PrivilegeDepth.Global]: 4,
+/**
+ * Fluent icons chosen to mirror the OOB Dataverse security-role editor depth glyphs,
+ * colored to echo that legend (None red, User teal, Business Unit blue, Parent-Child red,
+ * Organization green).
+ */
+const DEPTH_ICON: Record<PrivilegeDepth, DepthIconInfo> = {
+    [PrivilegeDepth.None]: { Icon: ProhibitedRegular, color: "#c50f1f" },
+    [PrivilegeDepth.Basic]: { Icon: PersonRegular, color: "#038387" },
+    [PrivilegeDepth.Local]: { Icon: PeopleRegular, color: "#0f6cbd" },
+    [PrivilegeDepth.Deep]: { Icon: PeopleTeamRegular, color: "#d13438" },
+    [PrivilegeDepth.Global]: { Icon: OrganizationRegular, color: "#107c10" },
 };
 
 interface SavedSelections {
     version: 1;
-    solutionId: string;
     baseRoleId: string;
     compareRoleIds: string[];
 }
@@ -57,11 +105,10 @@ function readSavedSelections(storageKey: string): SavedSelections | null {
         if (!raw) return null;
 
         const parsed = JSON.parse(raw) as Partial<SavedSelections>;
-        if (parsed.version !== 1 || typeof parsed.solutionId !== "string") return null;
+        if (parsed.version !== 1) return null;
 
         return {
             version: 1,
-            solutionId: parsed.solutionId,
             baseRoleId: typeof parsed.baseRoleId === "string" ? parsed.baseRoleId : "",
             compareRoleIds: Array.isArray(parsed.compareRoleIds) ? parsed.compareRoleIds.filter((value): value is string => typeof value === "string") : [],
         };
@@ -78,32 +125,16 @@ function saveSavedSelections(storageKey: string, selections: SavedSelections): v
     }
 }
 
-function getSolutionDisplayName(solution: DataverseSolution): string {
-    return solution.friendlyname?.trim() || solution.uniquename?.trim() || solution.solutionid;
-}
-
-function getSolutionGroupLabel(isManaged: boolean): string {
-    return isManaged ? "Managed Solutions" : "Unmanaged Solutions";
-}
-
 function getRoleGroupLabel(isManaged: boolean): string {
     return isManaged ? "Managed Roles" : "Unmanaged Roles";
 }
 
-function getRoleOriginLabel(role: SecurityRole): string {
-    if (Boolean(role.isautoassigned)) return "Auto-assigned";
-    if (role.issystemgenerated) return "System";
-    if (role.roletemplateid) return "Template";
-    return "Custom";
-}
-
 function getRoleDisplayName(role: SecurityRole, duplicateNames: Set<string>): string {
-    const parts = [role.name];
+    // Disambiguate same-named roles by business unit; otherwise show the plain role name.
     if (duplicateNames.has(role.name) && role.businessunitName) {
-        parts.push(role.businessunitName);
+        return `${role.name} · ${role.businessunitName}`;
     }
-    parts.push(getRoleOriginLabel(role));
-    return parts.join(" · ");
+    return role.name;
 }
 
 function normalizeSelections(preferredIds: string[], validIds: Set<string>, disallowIds: Set<string> = new Set<string>()): string[] {
@@ -120,25 +151,18 @@ function normalizeSelections(preferredIds: string[], validIds: Set<string>, disa
     return normalized;
 }
 
-/** Renders 4 dots indicating the privilege depth (filled up to the depth level). */
-function DepthDots({ depth }: { depth: PrivilegeDepth }) {
-    const filledCount = DEPTH_FILLED_COUNT[depth] ?? 0;
-    const color = DEPTH_COLORS[depth];
+/** Renders the Fluent icon representing a privilege depth level. */
+function DepthIcon({ depth }: { depth: PrivilegeDepth }) {
+    const { Icon, color } = DEPTH_ICON[depth] ?? DEPTH_ICON[PrivilegeDepth.None];
     return (
         <Tooltip content={DEPTH_LABELS[depth]} relationship="label">
-            <span className="depth-dots" aria-label={DEPTH_LABELS[depth]}>
-                {[0, 1, 2, 3].map((i) => (
-                    <span key={i} className="depth-dot" style={{ background: i < filledCount ? color : "var(--dot-empty)" }} />
-                ))}
-            </span>
+            <Icon className="depth-icon" style={{ color }} aria-label={DEPTH_LABELS[depth]} />
         </Tooltip>
     );
 }
 
 export default function App() {
-    const [solutions, setSolutions] = useState<DataverseSolution[]>([]);
     const [roles, setRoles] = useState<SecurityRole[]>([]);
-    const [selectedSolutionId, setSelectedSolutionId] = useState<string>("");
     const [loadingEnvironment, setLoadingEnvironment] = useState(false);
     const [loadingRoles, setLoadingRoles] = useState(false);
     const [baseRoleId, setBaseRoleId] = useState<string>("");
@@ -149,6 +173,8 @@ export default function App() {
     const [error, setError] = useState<string>("");
     const [searchTerm, setSearchTerm] = useState("");
     const [diffFilter, setDiffFilter] = useState<DiffFilter>("differences");
+    const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+    const [selectedOperations, setSelectedOperations] = useState<string[]>([]);
     const connectorRef = useRef<DataverseConnector | null>(null);
     const storageKeyRef = useRef<string>("");
     const initializedRef = useRef(false);
@@ -162,24 +188,16 @@ export default function App() {
 
         saveSavedSelections(storageKeyRef.current, {
             version: 1,
-            solutionId: selectedSolutionId,
             baseRoleId,
             compareRoleIds: compareRoleIds.filter((id) => id !== ""),
         });
-    }, [baseRoleId, compareRoleIds, selectedSolutionId]);
+    }, [baseRoleId, compareRoleIds]);
 
-    const applySelectionDefaults = (availableRoles: SecurityRole[], savedSelections: SavedSelections | null, solutionId: string) => {
+    const applySelectionDefaults = (availableRoles: SecurityRole[], savedSelections: SavedSelections | null) => {
         const validRoleIds = new Set(availableRoles.map((role) => role.roleid));
 
-        const baseId =
-            savedSelections?.solutionId === solutionId && savedSelections.baseRoleId && validRoleIds.has(savedSelections.baseRoleId)
-                ? savedSelections.baseRoleId
-                : "";
-
-        const compareIds =
-            savedSelections?.solutionId === solutionId
-                ? normalizeSelections(savedSelections.compareRoleIds, validRoleIds, new Set(baseId ? [baseId] : []))
-                : [];
+        const baseId = savedSelections?.baseRoleId && validRoleIds.has(savedSelections.baseRoleId) ? savedSelections.baseRoleId : "";
+        const compareIds = savedSelections ? normalizeSelections(savedSelections.compareRoleIds, validRoleIds, new Set(baseId ? [baseId] : [])) : [];
 
         setBaseRoleId(baseId);
         setCompareRoleIds(compareIds.length > 0 ? compareIds : [""]);
@@ -198,27 +216,16 @@ export default function App() {
             storageKeyRef.current = buildStorageKey(conn.url);
 
             const savedSelections = readSavedSelections(storageKeyRef.current);
-            const fetchedSolutions = await connectorRef.current.fetchSolutions();
-            setSolutions(fetchedSolutions);
-
-            const validSolutionIds = new Set(fetchedSolutions.map((solution) => solution.solutionid));
-            const preferredSolutionId =
-                savedSelections?.solutionId && validSolutionIds.has(savedSelections.solutionId)
-                    ? savedSelections.solutionId
-                    : fetchedSolutions.find((solution) => !solution.ismanaged)?.solutionid ?? fetchedSolutions[0]?.solutionid ?? "";
-
-            setSelectedSolutionId(preferredSolutionId);
-
-            const fetchedRoles = preferredSolutionId ? await connectorRef.current.fetchRoles(preferredSolutionId) : [];
+            const fetchedRoles = await connectorRef.current.fetchRoles();
             setRoles(fetchedRoles);
-            applySelectionDefaults(fetchedRoles, savedSelections, preferredSolutionId);
+            applySelectionDefaults(fetchedRoles, savedSelections);
 
             setComparisonData([]);
             setComparedRoleIds([]);
-            initializedRef.current = fetchedSolutions.length > 0;
+            initializedRef.current = fetchedRoles.length > 0;
 
-            if (!fetchedSolutions.length) {
-                setError("No solutions containing security roles were found in the connected environment.");
+            if (!fetchedRoles.length) {
+                setError("No security roles were found in the connected environment.");
             }
         } catch (err: any) {
             setError(err.message || "Failed to load security roles");
@@ -226,35 +233,6 @@ export default function App() {
             setLoadingEnvironment(false);
             setLoadingRoles(false);
         }
-    };
-
-    const loadRolesForSolution = async (solutionId: string) => {
-        if (!connectorRef.current) return;
-
-        setLoadingRoles(true);
-        setError("");
-
-        try {
-            const fetchedRoles = solutionId ? await connectorRef.current.fetchRoles(solutionId) : [];
-            setRoles(fetchedRoles);
-            setComparisonData([]);
-            setComparedRoleIds([]);
-            setBaseRoleId("");
-            setCompareRoleIds([""]);
-
-            if (!fetchedRoles.length) {
-                setError("No roles were found for the selected solution.");
-            }
-        } catch (err: any) {
-            setError(err.message || "Failed to load roles for the selected solution");
-        } finally {
-            setLoadingRoles(false);
-        }
-    };
-
-    const handleSolutionChange = async (nextSolutionId: string) => {
-        setSelectedSolutionId(nextSolutionId);
-        await loadRolesForSolution(nextSolutionId);
     };
 
     const addCompareSlot = () => {
@@ -271,16 +249,18 @@ export default function App() {
         setCompareRoleIds((prev) => prev.map((id, i) => (i === index ? value : id)));
     };
 
-    const canCompare = !!selectedSolutionId && !!baseRoleId && compareRoleIds.some((id) => id !== "");
+    const canCompare = !!baseRoleId && compareRoleIds.some((id) => id !== "");
 
-    const runComparison = async () => {
-        if (!canCompare || !connectorRef.current) return;
+    const runComparisonWith = async (baseId: string, compareIds: string[]) => {
+        if (!connectorRef.current) return;
+        const activeCompareIds = compareIds.filter((id) => id !== "");
+        if (!baseId || activeCompareIds.length === 0) return;
+
         setComparing(true);
         setError("");
         setComparisonData([]);
         try {
-            const activeCompareIds = compareRoleIds.filter((id) => id !== "");
-            const allIds = [baseRoleId, ...activeCompareIds];
+            const allIds = [baseId, ...activeCompareIds];
             const data = await connectorRef.current.buildComparisonData(allIds);
             setComparisonData(data);
             setComparedRoleIds(allIds);
@@ -292,13 +272,22 @@ export default function App() {
         }
     };
 
+    const runComparison = () => runComparisonWith(baseRoleId, compareRoleIds);
+
+    // Swap a compare-slot role with the current base role, then refresh the comparison.
+    const setCompareRoleAsBase = async (index: number) => {
+        const promotedRoleId = compareRoleIds[index];
+        if (!promotedRoleId) return;
+        const nextCompareIds = compareRoleIds.map((id, i) => (i === index ? baseRoleId : id));
+        setBaseRoleId(promotedRoleId);
+        setCompareRoleIds(nextCompareIds);
+        await runComparisonWith(promotedRoleId, nextCompareIds);
+    };
+
     const getRoleName = (roleId: string) => roles.find((r) => r.roleid === roleId)?.name ?? roleId;
 
     const getEntityLabel = (priv: ParsedPrivilege) => `${priv.entityDisplayName} (${priv.entitySchemaName})`;
 
-    const selectedSolution = solutions.find((solution) => solution.solutionid === selectedSolutionId);
-    const unmanagedSolutions = solutions.filter((solution) => !solution.ismanaged);
-    const managedSolutions = solutions.filter((solution) => solution.ismanaged);
     const unmanagedRoles = roles.filter((role) => !role.ismanaged);
     const managedRoles = roles.filter((role) => role.ismanaged);
     const duplicateRoleNames = useMemo(() => {
@@ -340,6 +329,31 @@ export default function App() {
         }
     };
 
+    // Distinct category labels present in the data, preserving the connector's ordering.
+    const availableCategories = useMemo(() => {
+        const seen: string[] = [];
+        const set = new Set<string>();
+        for (const priv of comparisonData) {
+            if (!set.has(priv.categoryLabel)) {
+                set.add(priv.categoryLabel);
+                seen.push(priv.categoryLabel);
+            }
+        }
+        return seen;
+    }, [comparisonData]);
+
+    // Operations present in the data, in a stable canonical order.
+    const availableOperations = useMemo(() => {
+        const present = new Set(comparisonData.map((priv) => priv.operation));
+        return OPERATION_ORDER.filter((op) => present.has(op));
+    }, [comparisonData]);
+
+    // Default both multiselect filters to "all" whenever a new comparison is run.
+    useEffect(() => {
+        setSelectedCategories([ALL_VALUE]);
+        setSelectedOperations([ALL_VALUE]);
+    }, [comparisonData]); // eslint-disable-line react-hooks/exhaustive-deps
+
     const filteredData = comparisonData.filter((priv) => {
         if (searchTerm) {
             const term = searchTerm.toLowerCase();
@@ -347,6 +361,8 @@ export default function App() {
                 return false;
             }
         }
+        if (!passesMultiSelect(priv.categoryLabel, selectedCategories)) return false;
+        if (!passesMultiSelect(priv.operation, selectedOperations)) return false;
         return matchesDiffFilter(priv);
     });
 
@@ -380,45 +396,11 @@ export default function App() {
     return (
         <div className="src-root">
             <div className="selector-bar">
-                <div className="solution-panel">
-                    <div className="role-selector-group solution-selector-group">
-                        <label className="role-label base-label">Solution</label>
-                        <div className="select-wrapper">
-                            <select
-                                className="role-select"
-                                value={selectedSolutionId}
-                                onChange={(e) => void handleSolutionChange(e.target.value)}
-                                disabled={loadingEnvironment || loadingRoles}
-                            >
-                                <option value="">— Select solution —</option>
-                                <optgroup label={getSolutionGroupLabel(false)}>
-                                    {unmanagedSolutions.map((solution) => (
-                                        <option key={solution.solutionid} value={solution.solutionid}>
-                                            {getSolutionDisplayName(solution)}
-                                        </option>
-                                    ))}
-                                </optgroup>
-                                <optgroup label={getSolutionGroupLabel(true)}>
-                                    {managedSolutions.map((solution) => (
-                                        <option key={solution.solutionid} value={solution.solutionid}>
-                                            {getSolutionDisplayName(solution)}
-                                        </option>
-                                    ))}
-                                </optgroup>
-                            </select>
-                        </div>
-                    </div>
-                    <div className="solution-subtext">
-                        <span className="field-note">Selections are remembered per environment in this browser.</span>
-                        {selectedSolution && <span className="field-meta">Loaded from: {getSolutionDisplayName(selectedSolution)}</span>}
-                    </div>
-                </div>
-
-                <div className="selector-content">
+                <div className="selector-row">
                     <div className="role-selector-group">
                         <label className="role-label base-label">Base Role</label>
                         <div className="select-wrapper">
-                            <select className="role-select" value={baseRoleId} onChange={(e) => setBaseRoleId(e.target.value)} disabled={loadingEnvironment || loadingRoles || !selectedSolutionId}>
+                            <select className="role-select" value={baseRoleId} onChange={(e) => setBaseRoleId(e.target.value)} disabled={loadingEnvironment || loadingRoles}>
                                 <option value="">— Select base role —</option>
                                 <optgroup label={getRoleGroupLabel(false)}>
                                     {unmanagedRoles.map((role) => (
@@ -441,13 +423,20 @@ export default function App() {
                     <div className="compare-slots">
                         {compareRoleIds.map((id, idx) => (
                             <div key={idx} className="role-selector-group">
-                                <label className="role-label">Compare {idx + 1}</label>
+                                <label className="role-label">
+                                    Compare {idx + 1}
+                                    {id && (
+                                        <button type="button" className="set-base-link" onClick={() => void setCompareRoleAsBase(idx)} title="Swap this role with the base role and re-compare">
+                                            (Set as Base)
+                                        </button>
+                                    )}
+                                </label>
                                 <div className="select-wrapper compare-select-row">
                                     <select
                                         className="role-select"
                                         value={id}
                                         onChange={(e) => setCompareRole(idx, e.target.value)}
-                                        disabled={loadingEnvironment || loadingRoles || !selectedSolutionId}
+                                        disabled={loadingEnvironment || loadingRoles}
                                     >
                                         <option value="">— Select role —</option>
                                         <optgroup label={getRoleGroupLabel(false)}>
@@ -485,7 +474,7 @@ export default function App() {
                         ))}
 
                         {compareRoleIds.length < MAX_COMPARE_ROLES && (
-                            <button className="add-slot-btn" onClick={addCompareSlot} disabled={loadingEnvironment || loadingRoles || !selectedSolutionId}>
+                            <button className="add-slot-btn" onClick={addCompareSlot} disabled={loadingEnvironment || loadingRoles}>
                                 + Add Role
                             </button>
                         )}
@@ -519,6 +508,40 @@ export default function App() {
                         size="small"
                         className="search-box"
                     />
+                    <Dropdown
+                        className="multi-filter"
+                        size="small"
+                        multiselect
+                        placeholder="Groups"
+                        selectedOptions={selectedCategories}
+                        value={multiSelectSummary(selectedCategories, availableCategories, "groups")}
+                        onOptionSelect={(_e, data) => setSelectedCategories((prev) => toggleMultiSelect(data.optionValue ?? "", prev, availableCategories))}
+                        aria-label="Filter by group"
+                    >
+                        <Option value={ALL_VALUE}>All groups</Option>
+                        {availableCategories.map((label) => (
+                            <Option key={label} value={label}>
+                                {label}
+                            </Option>
+                        ))}
+                    </Dropdown>
+                    <Dropdown
+                        className="multi-filter"
+                        size="small"
+                        multiselect
+                        placeholder="Operations"
+                        selectedOptions={selectedOperations}
+                        value={multiSelectSummary(selectedOperations, availableOperations, "operations")}
+                        onOptionSelect={(_e, data) => setSelectedOperations((prev) => toggleMultiSelect(data.optionValue ?? "", prev, availableOperations))}
+                        aria-label="Filter by operation"
+                    >
+                        <Option value={ALL_VALUE}>All operations</Option>
+                        {availableOperations.map((op) => (
+                            <Option key={op} value={op}>
+                                {operationLabel(op)}
+                            </Option>
+                        ))}
+                    </Dropdown>
                     <select
                         className="diff-filter-select"
                         value={diffFilter}
@@ -551,11 +574,6 @@ export default function App() {
                                 {comparedRoleIds.map((rid, i) => (
                                     <th key={rid} className={`col-role ${i === 0 ? "col-base" : ""}`} title={getRoleName(rid)}>
                                         <span className="role-col-name">{getRoleName(rid)}</span>
-                                        {i === 0 && (
-                                            <Badge appearance="tint" color="brand" size="small" className="base-badge">
-                                                Base
-                                            </Badge>
-                                        )}
                                     </th>
                                 ))}
                             </tr>
@@ -583,7 +601,7 @@ export default function App() {
                                                         </div>
                                                     </td>
                                                 )}
-                                                <td className="col-operation">{priv.operation}</td>
+                                                <td className="col-operation">{operationLabel(priv.operation)}</td>
                                                 {comparedRoleIds.map((rid, ci) => {
                                                     const depth = priv.depthByRole[rid] ?? PrivilegeDepth.None;
                                                     const baseRank = depthRank(priv.depthByRole[comparedRoleIds[0]]);
@@ -591,21 +609,17 @@ export default function App() {
                                                     const direction = ci === 0 ? "none" : rank > baseRank ? "more" : rank < baseRank ? "less" : "none";
                                                     return (
                                                         <td key={rid} className={`col-role-cell ${ci === 0 ? "col-base-cell" : ""}`}>
-                                                            <div className="cell-content">
-                                                                <span className="diff-icon-slot">
-                                                                    {direction === "more" && (
-                                                                        <Tooltip content="More permission than base" relationship="label">
-                                                                            <AddCircleFilled className="diff-icon diff-more" aria-label="More permission than base" />
-                                                                        </Tooltip>
-                                                                    )}
-                                                                    {direction === "less" && (
-                                                                        <Tooltip content="Less permission than base" relationship="label">
-                                                                            <SubtractCircleFilled className="diff-icon diff-less" aria-label="Less permission than base" />
-                                                                        </Tooltip>
-                                                                    )}
-                                                                </span>
-                                                                <DepthDots depth={depth} />
-                                                            </div>
+                                                            {direction === "more" && (
+                                                                <Tooltip content="More permission than base" relationship="label">
+                                                                    <AddCircleFilled className="diff-icon diff-more" aria-label="More permission than base" />
+                                                                </Tooltip>
+                                                            )}
+                                                            {direction === "less" && (
+                                                                <Tooltip content="Less permission than base" relationship="label">
+                                                                    <SubtractCircleFilled className="diff-icon diff-less" aria-label="Less permission than base" />
+                                                                </Tooltip>
+                                                            )}
+                                                            <DepthIcon depth={depth} />
                                                         </td>
                                                     );
                                                 })}
@@ -630,7 +644,7 @@ export default function App() {
                 <div className="legend-bar">
                     {(Object.entries(DEPTH_LABELS) as [string, string][]).map(([depth, label]) => (
                         <span key={depth} className="legend-item">
-                            <DepthDots depth={Number(depth) as PrivilegeDepth} />
+                            <DepthIcon depth={Number(depth) as PrivilegeDepth} />
                             <span className="legend-label">{label}</span>
                         </span>
                     ))}
@@ -648,7 +662,7 @@ export default function App() {
             {!hasResults && !comparing && !loadingRoles && !loadingEnvironment && !error && (
                 <div className="empty-state">
                     <p>
-                        Select a solution, then choose a base role and one or more comparison roles before clicking <strong>Compare</strong>.
+                        Choose a base role and one or more comparison roles, then click <strong>Compare</strong>.
                     </p>
                 </div>
             )}

--- a/tools/security-role-comparator/src/App.tsx
+++ b/tools/security-role-comparator/src/App.tsx
@@ -1,7 +1,6 @@
 import { Button, Dropdown, MessageBar, MessageBarBody, Option, SearchBox, Spinner, Tooltip } from "@fluentui/react-components";
 import {
     AddCircleFilled,
-    ArrowSyncRegular,
     DismissCircleRegular,
     OrganizationRegular,
     PeopleRegular,
@@ -92,6 +91,11 @@ interface SavedSelections {
     compareRoleIds: string[];
 }
 
+interface RoleSelections {
+    baseRoleId: string;
+    compareRoleIds: string[];
+}
+
 function buildStorageKey(envUrl: string): string {
     try {
         return `${STORAGE_PREFIX}:${new URL(envUrl).origin}`;
@@ -171,6 +175,7 @@ export default function App() {
     const [comparing, setComparing] = useState(false);
     const [comparisonData, setComparisonData] = useState<ParsedPrivilege[]>([]);
     const [comparedRoleIds, setComparedRoleIds] = useState<string[]>([]);
+    const [hasComparedOnce, setHasComparedOnce] = useState(false);
     const [error, setError] = useState<string>("");
     const [searchTerm, setSearchTerm] = useState("");
     const [diffFilter, setDiffFilter] = useState<DiffFilter>("differences");
@@ -194,17 +199,24 @@ export default function App() {
         });
     }, [baseRoleId, compareRoleIds]);
 
-    const applySelectionDefaults = (availableRoles: SecurityRole[], savedSelections: SavedSelections | null) => {
+    const getSelectionDefaults = (availableRoles: SecurityRole[], savedSelections: SavedSelections | null): RoleSelections => {
         const validRoleIds = new Set(availableRoles.map((role) => role.roleid));
 
         const baseId = savedSelections?.baseRoleId && validRoleIds.has(savedSelections.baseRoleId) ? savedSelections.baseRoleId : "";
         const compareIds = savedSelections ? normalizeSelections(savedSelections.compareRoleIds, validRoleIds, new Set(baseId ? [baseId] : [])) : [];
 
-        setBaseRoleId(baseId);
-        setCompareRoleIds(compareIds.length > 0 ? compareIds : [""]);
+        return {
+            baseRoleId: baseId,
+            compareRoleIds: compareIds.length > 0 ? compareIds : [""],
+        };
     };
 
-    const loadEnvironment = async () => {
+    const applySelectionDefaults = ({ baseRoleId: nextBaseRoleId, compareRoleIds: nextCompareRoleIds }: RoleSelections) => {
+        setBaseRoleId(nextBaseRoleId);
+        setCompareRoleIds(nextCompareRoleIds);
+    };
+
+    const loadEnvironment = async (): Promise<RoleSelections | null> => {
         setLoadingEnvironment(true);
         setError("");
 
@@ -219,7 +231,9 @@ export default function App() {
             const savedSelections = readSavedSelections(storageKeyRef.current);
             const fetchedRoles = await connectorRef.current.fetchRoles();
             setRoles(fetchedRoles);
-            applySelectionDefaults(fetchedRoles, savedSelections);
+
+            const resolvedSelections = getSelectionDefaults(fetchedRoles, savedSelections);
+            applySelectionDefaults(resolvedSelections);
 
             setComparisonData([]);
             setComparedRoleIds([]);
@@ -228,12 +242,29 @@ export default function App() {
             if (!fetchedRoles.length) {
                 setError("No security roles were found in the connected environment.");
             }
+
+            return resolvedSelections;
         } catch (err: any) {
             setError(err.message || "Failed to load security roles");
+            return null;
         } finally {
             setLoadingEnvironment(false);
             setLoadingRoles(false);
         }
+    };
+
+    const runRefreshAndComparison = async () => {
+        const refreshedSelections = await loadEnvironment();
+        if (!refreshedSelections) return;
+        await runComparisonWith(refreshedSelections.baseRoleId, refreshedSelections.compareRoleIds);
+    };
+
+    const runPrimaryAction = async () => {
+        if (hasComparedOnce) {
+            await runRefreshAndComparison();
+            return;
+        }
+        await runComparison();
     };
 
     const addCompareSlot = () => {
@@ -265,6 +296,7 @@ export default function App() {
             const data = await connectorRef.current.buildComparisonData(allIds);
             setComparisonData(data);
             setComparedRoleIds(allIds);
+            setHasComparedOnce(true);
         } catch (err: any) {
             setError(err.message || "Comparison failed");
             await DataverseConnector.showMessage("Error", err.message || "Comparison failed", "error");
@@ -411,6 +443,7 @@ export default function App() {
 
     const columnCount = 2 + comparedRoleIds.length + (showCombined ? 1 : 0);
     const hasResults = comparisonData.length > 0;
+    const actionLabel = hasComparedOnce ? "Refresh" : "Compare";
 
 
     return (
@@ -504,11 +537,15 @@ export default function App() {
                         {loadingEnvironment || loadingRoles ? (
                             <Spinner size="tiny" label="Loading selections…" labelPosition="after" />
                         ) : (
-                            <Button appearance="subtle" icon={<ArrowSyncRegular />} onClick={() => void loadEnvironment()} title="Refresh selections" size="small" />
+                            <Button
+                                appearance="primary"
+                                onClick={() => void runPrimaryAction()}
+                                disabled={!canCompare || comparing || loadingEnvironment || loadingRoles}
+                                size="medium"
+                            >
+                                {comparing ? <Spinner size="tiny" /> : actionLabel}
+                            </Button>
                         )}
-                        <Button appearance="primary" onClick={runComparison} disabled={!canCompare || comparing || loadingEnvironment || loadingRoles} size="medium">
-                            {comparing ? <Spinner size="tiny" /> : "Compare"}
-                        </Button>
                     </div>
                 </div>
             </div>
@@ -698,7 +735,7 @@ export default function App() {
             {!hasResults && !comparing && !loadingRoles && !loadingEnvironment && !error && (
                 <div className="empty-state">
                     <p>
-                        Choose a base role and one or more comparison roles, then click <strong>Compare</strong>.
+                        Choose a base role and one or more comparison roles, then click <strong>{actionLabel}</strong>.
                     </p>
                 </div>
             )}

--- a/tools/security-role-comparator/src/App.tsx
+++ b/tools/security-role-comparator/src/App.tsx
@@ -12,7 +12,7 @@ const STORAGE_PREFIX = "security-role-comparator:recent-selections:v1";
 type DiffFilter = "differences" | "more" | "less" | "same" | "all";
 
 const DIFF_FILTER_OPTIONS: { value: DiffFilter; label: string }[] = [
-    { value: "differences", label: "Differences only" },
+    { value: "differences", label: "All differences" },
     { value: "more", label: "More than base" },
     { value: "less", label: "Less than base" },
     { value: "same", label: "Same as base" },
@@ -218,7 +218,7 @@ export default function App() {
             initializedRef.current = fetchedSolutions.length > 0;
 
             if (!fetchedSolutions.length) {
-                setError("No solutions were found in the connected environment.");
+                setError("No solutions containing security roles were found in the connected environment.");
             }
         } catch (err: any) {
             setError(err.message || "Failed to load security roles");
@@ -407,6 +407,8 @@ export default function App() {
                                 </optgroup>
                             </select>
                         </div>
+                    </div>
+                    <div className="solution-subtext">
                         <span className="field-note">Selections are remembered per environment in this browser.</span>
                         {selectedSolution && <span className="field-meta">Loaded from: {getSolutionDisplayName(selectedSolution)}</span>}
                     </div>

--- a/tools/security-role-comparator/src/App.tsx
+++ b/tools/security-role-comparator/src/App.tsx
@@ -1,11 +1,24 @@
-import { Badge, Button, Checkbox, MessageBar, MessageBarBody, SearchBox, Spinner, Tooltip } from "@fluentui/react-components";
-import { ArrowSyncRegular, DismissCircleRegular } from "@fluentui/react-icons";
-import { useEffect, useRef, useState } from "react";
-import { DEPTH_LABELS, ParsedPrivilege, PrivilegeDepth, SecurityRole } from "./models/interfaces";
+import { Badge, Button, MessageBar, MessageBarBody, SearchBox, Spinner, Tooltip } from "@fluentui/react-components";
+import { AddCircleFilled, ArrowSyncRegular, DismissCircleRegular, SubtractCircleFilled } from "@fluentui/react-icons";
+import { useEffect, useMemo, useRef, useState, Fragment } from "react";
+import { DataverseSolution, DEPTH_LABELS, depthRank, ParsedPrivilege, PrivilegeDepth, SecurityRole } from "./models/interfaces";
 import "./styles.css";
 import { DataverseConnector } from "./utils/dataverseClient";
 
 const MAX_COMPARE_ROLES = 5;
+const STORAGE_PREFIX = "security-role-comparator:recent-selections:v1";
+
+/** Row-level filter modes for the comparison grid. */
+type DiffFilter = "differences" | "more" | "less" | "same" | "all";
+
+const DIFF_FILTER_OPTIONS: { value: DiffFilter; label: string }[] = [
+    { value: "differences", label: "Differences only" },
+    { value: "more", label: "More than base" },
+    { value: "less", label: "Less than base" },
+    { value: "same", label: "Same as base" },
+    { value: "all", label: "Show all" },
+];
+
 const DEPTH_COLORS: Record<PrivilegeDepth, string> = {
     [PrivilegeDepth.None]: "var(--depth-none)",
     [PrivilegeDepth.Basic]: "var(--depth-basic)",
@@ -23,6 +36,90 @@ const DEPTH_FILLED_COUNT: Record<PrivilegeDepth, number> = {
     [PrivilegeDepth.Global]: 4,
 };
 
+interface SavedSelections {
+    version: 1;
+    solutionId: string;
+    baseRoleId: string;
+    compareRoleIds: string[];
+}
+
+function buildStorageKey(envUrl: string): string {
+    try {
+        return `${STORAGE_PREFIX}:${new URL(envUrl).origin}`;
+    } catch {
+        return `${STORAGE_PREFIX}:${envUrl}`;
+    }
+}
+
+function readSavedSelections(storageKey: string): SavedSelections | null {
+    try {
+        const raw = window.localStorage.getItem(storageKey);
+        if (!raw) return null;
+
+        const parsed = JSON.parse(raw) as Partial<SavedSelections>;
+        if (parsed.version !== 1 || typeof parsed.solutionId !== "string") return null;
+
+        return {
+            version: 1,
+            solutionId: parsed.solutionId,
+            baseRoleId: typeof parsed.baseRoleId === "string" ? parsed.baseRoleId : "",
+            compareRoleIds: Array.isArray(parsed.compareRoleIds) ? parsed.compareRoleIds.filter((value): value is string => typeof value === "string") : [],
+        };
+    } catch {
+        return null;
+    }
+}
+
+function saveSavedSelections(storageKey: string, selections: SavedSelections): void {
+    try {
+        window.localStorage.setItem(storageKey, JSON.stringify(selections));
+    } catch {
+        // Browser storage may be unavailable or disabled; persistence is optional.
+    }
+}
+
+function getSolutionDisplayName(solution: DataverseSolution): string {
+    return solution.friendlyname?.trim() || solution.uniquename?.trim() || solution.solutionid;
+}
+
+function getSolutionGroupLabel(isManaged: boolean): string {
+    return isManaged ? "Managed Solutions" : "Unmanaged Solutions";
+}
+
+function getRoleGroupLabel(isManaged: boolean): string {
+    return isManaged ? "Managed Roles" : "Unmanaged Roles";
+}
+
+function getRoleOriginLabel(role: SecurityRole): string {
+    if (Boolean(role.isautoassigned)) return "Auto-assigned";
+    if (role.issystemgenerated) return "System";
+    if (role.roletemplateid) return "Template";
+    return "Custom";
+}
+
+function getRoleDisplayName(role: SecurityRole, duplicateNames: Set<string>): string {
+    const parts = [role.name];
+    if (duplicateNames.has(role.name) && role.businessunitName) {
+        parts.push(role.businessunitName);
+    }
+    parts.push(getRoleOriginLabel(role));
+    return parts.join(" · ");
+}
+
+function normalizeSelections(preferredIds: string[], validIds: Set<string>, disallowIds: Set<string> = new Set<string>()): string[] {
+    const seen = new Set<string>();
+    const normalized: string[] = [];
+
+    for (const id of preferredIds) {
+        if (!id || !validIds.has(id) || disallowIds.has(id) || seen.has(id)) continue;
+        seen.add(id);
+        normalized.push(id);
+        if (normalized.length === MAX_COMPARE_ROLES) break;
+    }
+
+    return normalized;
+}
+
 /** Renders 4 dots indicating the privilege depth (filled up to the depth level). */
 function DepthDots({ depth }: { depth: PrivilegeDepth }) {
     const filledCount = DEPTH_FILLED_COUNT[depth] ?? 0;
@@ -39,7 +136,10 @@ function DepthDots({ depth }: { depth: PrivilegeDepth }) {
 }
 
 export default function App() {
+    const [solutions, setSolutions] = useState<DataverseSolution[]>([]);
     const [roles, setRoles] = useState<SecurityRole[]>([]);
+    const [selectedSolutionId, setSelectedSolutionId] = useState<string>("");
+    const [loadingEnvironment, setLoadingEnvironment] = useState(false);
     const [loadingRoles, setLoadingRoles] = useState(false);
     const [baseRoleId, setBaseRoleId] = useState<string>("");
     const [compareRoleIds, setCompareRoleIds] = useState<string[]>([""]);
@@ -48,28 +148,113 @@ export default function App() {
     const [comparedRoleIds, setComparedRoleIds] = useState<string[]>([]);
     const [error, setError] = useState<string>("");
     const [searchTerm, setSearchTerm] = useState("");
-    const [diffsOnly, setDiffsOnly] = useState(false);
+    const [diffFilter, setDiffFilter] = useState<DiffFilter>("differences");
     const connectorRef = useRef<DataverseConnector | null>(null);
+    const storageKeyRef = useRef<string>("");
+    const initializedRef = useRef(false);
 
     useEffect(() => {
-        loadRoles();
+        void loadEnvironment();
     }, []);
 
-    const loadRoles = async () => {
-        setLoadingRoles(true);
+    useEffect(() => {
+        if (!initializedRef.current || !storageKeyRef.current) return;
+
+        saveSavedSelections(storageKeyRef.current, {
+            version: 1,
+            solutionId: selectedSolutionId,
+            baseRoleId,
+            compareRoleIds: compareRoleIds.filter((id) => id !== ""),
+        });
+    }, [baseRoleId, compareRoleIds, selectedSolutionId]);
+
+    const applySelectionDefaults = (availableRoles: SecurityRole[], savedSelections: SavedSelections | null, solutionId: string) => {
+        const validRoleIds = new Set(availableRoles.map((role) => role.roleid));
+
+        const baseId =
+            savedSelections?.solutionId === solutionId && savedSelections.baseRoleId && validRoleIds.has(savedSelections.baseRoleId)
+                ? savedSelections.baseRoleId
+                : "";
+
+        const compareIds =
+            savedSelections?.solutionId === solutionId
+                ? normalizeSelections(savedSelections.compareRoleIds, validRoleIds, new Set(baseId ? [baseId] : []))
+                : [];
+
+        setBaseRoleId(baseId);
+        setCompareRoleIds(compareIds.length > 0 ? compareIds : [""]);
+    };
+
+    const loadEnvironment = async () => {
+        setLoadingEnvironment(true);
         setError("");
+
         try {
             if (!window.toolboxAPI) throw new Error("Toolbox API not available");
             const conn = await window.toolboxAPI.connections.getActiveConnection();
             if (!conn?.url) throw new Error("No active connection found. Please connect to a Dataverse environment first.");
+
             connectorRef.current = new DataverseConnector(conn.url);
-            const fetchedRoles = await connectorRef.current.fetchRoles();
+            storageKeyRef.current = buildStorageKey(conn.url);
+
+            const savedSelections = readSavedSelections(storageKeyRef.current);
+            const fetchedSolutions = await connectorRef.current.fetchSolutions();
+            setSolutions(fetchedSolutions);
+
+            const validSolutionIds = new Set(fetchedSolutions.map((solution) => solution.solutionid));
+            const preferredSolutionId =
+                savedSelections?.solutionId && validSolutionIds.has(savedSelections.solutionId)
+                    ? savedSelections.solutionId
+                    : fetchedSolutions.find((solution) => !solution.ismanaged)?.solutionid ?? fetchedSolutions[0]?.solutionid ?? "";
+
+            setSelectedSolutionId(preferredSolutionId);
+
+            const fetchedRoles = preferredSolutionId ? await connectorRef.current.fetchRoles(preferredSolutionId) : [];
             setRoles(fetchedRoles);
+            applySelectionDefaults(fetchedRoles, savedSelections, preferredSolutionId);
+
+            setComparisonData([]);
+            setComparedRoleIds([]);
+            initializedRef.current = fetchedSolutions.length > 0;
+
+            if (!fetchedSolutions.length) {
+                setError("No solutions were found in the connected environment.");
+            }
         } catch (err: any) {
             setError(err.message || "Failed to load security roles");
         } finally {
+            setLoadingEnvironment(false);
             setLoadingRoles(false);
         }
+    };
+
+    const loadRolesForSolution = async (solutionId: string) => {
+        if (!connectorRef.current) return;
+
+        setLoadingRoles(true);
+        setError("");
+
+        try {
+            const fetchedRoles = solutionId ? await connectorRef.current.fetchRoles(solutionId) : [];
+            setRoles(fetchedRoles);
+            setComparisonData([]);
+            setComparedRoleIds([]);
+            setBaseRoleId("");
+            setCompareRoleIds([""]);
+
+            if (!fetchedRoles.length) {
+                setError("No roles were found for the selected solution.");
+            }
+        } catch (err: any) {
+            setError(err.message || "Failed to load roles for the selected solution");
+        } finally {
+            setLoadingRoles(false);
+        }
+    };
+
+    const handleSolutionChange = async (nextSolutionId: string) => {
+        setSelectedSolutionId(nextSolutionId);
+        await loadRolesForSolution(nextSolutionId);
     };
 
     const addCompareSlot = () => {
@@ -86,7 +271,7 @@ export default function App() {
         setCompareRoleIds((prev) => prev.map((id, i) => (i === index ? value : id)));
     };
 
-    const canCompare = baseRoleId && compareRoleIds.some((id) => id !== "");
+    const canCompare = !!selectedSolutionId && !!baseRoleId && compareRoleIds.some((id) => id !== "");
 
     const runComparison = async () => {
         if (!canCompare || !connectorRef.current) return;
@@ -109,96 +294,211 @@ export default function App() {
 
     const getRoleName = (roleId: string) => roles.find((r) => r.roleid === roleId)?.name ?? roleId;
 
-    // Filter logic
+    const getEntityLabel = (priv: ParsedPrivilege) => `${priv.entityDisplayName} (${priv.entitySchemaName})`;
+
+    const selectedSolution = solutions.find((solution) => solution.solutionid === selectedSolutionId);
+    const unmanagedSolutions = solutions.filter((solution) => !solution.ismanaged);
+    const managedSolutions = solutions.filter((solution) => solution.ismanaged);
+    const unmanagedRoles = roles.filter((role) => !role.ismanaged);
+    const managedRoles = roles.filter((role) => role.ismanaged);
+    const duplicateRoleNames = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const role of roles) {
+            counts.set(role.name, (counts.get(role.name) ?? 0) + 1);
+        }
+        return new Set(Array.from(counts.entries()).filter(([, count]) => count > 1).map(([name]) => name));
+    }, [roles]);
+
+    const baseRoleForResults = comparedRoleIds[0];
+
+    const getRowDiff = (priv: ParsedPrivilege) => {
+        const baseRank = depthRank(priv.depthByRole[baseRoleForResults]);
+        let hasMore = false;
+        let hasLess = false;
+        for (let i = 1; i < comparedRoleIds.length; i++) {
+            const rank = depthRank(priv.depthByRole[comparedRoleIds[i]]);
+            if (rank > baseRank) hasMore = true;
+            else if (rank < baseRank) hasLess = true;
+        }
+        return { hasMore, hasLess };
+    };
+
+    const matchesDiffFilter = (priv: ParsedPrivilege) => {
+        if (diffFilter === "all") return true;
+        const { hasMore, hasLess } = getRowDiff(priv);
+        switch (diffFilter) {
+            case "differences":
+                return hasMore || hasLess;
+            case "more":
+                return hasMore;
+            case "less":
+                return hasLess;
+            case "same":
+                return !hasMore && !hasLess;
+            default:
+                return true;
+        }
+    };
+
     const filteredData = comparisonData.filter((priv) => {
         if (searchTerm) {
             const term = searchTerm.toLowerCase();
-            if (!priv.entity.toLowerCase().includes(term) && !priv.operation.toLowerCase().includes(term) && !priv.rawName.toLowerCase().includes(term)) {
+            if (!priv.entitySearchText.includes(term) && !priv.operation.toLowerCase().includes(term) && !priv.rawName.toLowerCase().includes(term)) {
                 return false;
             }
         }
-        if (diffsOnly) {
-            const depths = comparedRoleIds.map((rid) => priv.depthByRole[rid] ?? PrivilegeDepth.None);
-            const allSame = depths.every((d) => d === depths[0]);
-            if (allSame) return false;
-        }
-        return true;
+        return matchesDiffFilter(priv);
     });
 
-    // Group filtered data by entity
-    const groupedData = filteredData.reduce<Record<string, ParsedPrivilege[]>>((acc, priv) => {
-        if (!acc[priv.entity]) acc[priv.entity] = [];
-        acc[priv.entity].push(priv);
-        return acc;
-    }, {});
+    // Two-level grouping: category (OOB tab / section) -> entity (or single misc privilege row).
+    const categoryGroups = useMemo(() => {
+        const categories = new Map<string, { key: string; label: string; kind: string; entityGroups: Map<string, ParsedPrivilege[]> }>();
+        for (const priv of filteredData) {
+            let category = categories.get(priv.categoryKey);
+            if (!category) {
+                category = { key: priv.categoryKey, label: priv.categoryLabel, kind: priv.categoryKind, entityGroups: new Map() };
+                categories.set(priv.categoryKey, category);
+            }
+            const rows = category.entityGroups.get(priv.entityLogicalName);
+            if (rows) rows.push(priv);
+            else category.entityGroups.set(priv.entityLogicalName, [priv]);
+        }
+        // filteredData preserves the connector's category/entity/operation ordering, so Map
+        // insertion order already reflects the intended display order.
+        return Array.from(categories.values()).map((category) => ({
+            key: category.key,
+            label: category.label,
+            kind: category.kind,
+            entityGroups: Array.from(category.entityGroups.entries()).map(([entityKey, rows]) => ({ entityKey, rows })),
+        }));
+    }, [filteredData]);
 
-    const sortedEntities = Object.keys(groupedData).sort((a, b) => a.localeCompare(b));
+    const columnCount = 2 + comparedRoleIds.length;
     const hasResults = comparisonData.length > 0;
+
 
     return (
         <div className="src-root">
-            {/* Role selectors */}
             <div className="selector-bar">
-                <div className="role-selector-group">
-                    <label className="role-label base-label">Base Role</label>
-                    <div className="select-wrapper">
-                        <select className="role-select" value={baseRoleId} onChange={(e) => setBaseRoleId(e.target.value)} disabled={loadingRoles}>
-                            <option value="">— Select base role —</option>
-                            {roles.map((r) => (
-                                <option key={r.roleid} value={r.roleid}>
-                                    {r.name}
-                                </option>
-                            ))}
-                        </select>
+                <div className="solution-panel">
+                    <div className="role-selector-group solution-selector-group">
+                        <label className="role-label base-label">Solution</label>
+                        <div className="select-wrapper">
+                            <select
+                                className="role-select"
+                                value={selectedSolutionId}
+                                onChange={(e) => void handleSolutionChange(e.target.value)}
+                                disabled={loadingEnvironment || loadingRoles}
+                            >
+                                <option value="">— Select solution —</option>
+                                <optgroup label={getSolutionGroupLabel(false)}>
+                                    {unmanagedSolutions.map((solution) => (
+                                        <option key={solution.solutionid} value={solution.solutionid}>
+                                            {getSolutionDisplayName(solution)}
+                                        </option>
+                                    ))}
+                                </optgroup>
+                                <optgroup label={getSolutionGroupLabel(true)}>
+                                    {managedSolutions.map((solution) => (
+                                        <option key={solution.solutionid} value={solution.solutionid}>
+                                            {getSolutionDisplayName(solution)}
+                                        </option>
+                                    ))}
+                                </optgroup>
+                            </select>
+                        </div>
+                        <span className="field-note">Selections are remembered per environment in this browser.</span>
+                        {selectedSolution && <span className="field-meta">Loaded from: {getSolutionDisplayName(selectedSolution)}</span>}
                     </div>
                 </div>
 
-                <div className="compare-slots">
-                    {compareRoleIds.map((id, idx) => (
-                        <div key={idx} className="role-selector-group">
-                            <label className="role-label">Compare {idx + 1}</label>
-                            <div className="select-wrapper compare-select-row">
-                                <select className="role-select" value={id} onChange={(e) => setCompareRole(idx, e.target.value)} disabled={loadingRoles}>
-                                    <option value="">— Select role —</option>
-                                    {roles
-                                        .filter((r) => r.roleid !== baseRoleId && !compareRoleIds.some((cid, ci) => ci !== idx && cid === r.roleid))
-                                        .map((r) => (
-                                            <option key={r.roleid} value={r.roleid}>
-                                                {r.name}
-                                            </option>
-                                        ))}
-                                </select>
-                                {compareRoleIds.length > 1 && (
-                                    <button
-                                        type="button"
-                                        className="remove-slot-btn"
-                                        onClick={() => removeCompareSlot(idx)}
-                                        title="Remove"
-                                        aria-label="Remove compare role"
-                                    >
-                                        <DismissCircleRegular />
-                                    </button>
-                                )}
-                            </div>
+                <div className="selector-content">
+                    <div className="role-selector-group">
+                        <label className="role-label base-label">Base Role</label>
+                        <div className="select-wrapper">
+                            <select className="role-select" value={baseRoleId} onChange={(e) => setBaseRoleId(e.target.value)} disabled={loadingEnvironment || loadingRoles || !selectedSolutionId}>
+                                <option value="">— Select base role —</option>
+                                <optgroup label={getRoleGroupLabel(false)}>
+                                    {unmanagedRoles.map((role) => (
+                                        <option key={role.roleid} value={role.roleid}>
+                                            {getRoleDisplayName(role, duplicateRoleNames)}
+                                        </option>
+                                    ))}
+                                </optgroup>
+                                <optgroup label={getRoleGroupLabel(true)}>
+                                    {managedRoles.map((role) => (
+                                        <option key={role.roleid} value={role.roleid}>
+                                            {getRoleDisplayName(role, duplicateRoleNames)}
+                                        </option>
+                                    ))}
+                                </optgroup>
+                            </select>
                         </div>
-                    ))}
+                    </div>
 
-                    {compareRoleIds.length < MAX_COMPARE_ROLES && (
-                        <button className="add-slot-btn" onClick={addCompareSlot} disabled={loadingRoles}>
-                            + Add Role
-                        </button>
-                    )}
-                </div>
+                    <div className="compare-slots">
+                        {compareRoleIds.map((id, idx) => (
+                            <div key={idx} className="role-selector-group">
+                                <label className="role-label">Compare {idx + 1}</label>
+                                <div className="select-wrapper compare-select-row">
+                                    <select
+                                        className="role-select"
+                                        value={id}
+                                        onChange={(e) => setCompareRole(idx, e.target.value)}
+                                        disabled={loadingEnvironment || loadingRoles || !selectedSolutionId}
+                                    >
+                                        <option value="">— Select role —</option>
+                                        <optgroup label={getRoleGroupLabel(false)}>
+                                            {unmanagedRoles
+                                                .filter((role) => role.roleid !== baseRoleId && !compareRoleIds.some((cid, ci) => ci !== idx && cid === role.roleid))
+                                                .map((role) => (
+                                                    <option key={role.roleid} value={role.roleid}>
+                                                        {getRoleDisplayName(role, duplicateRoleNames)}
+                                                    </option>
+                                                ))}
+                                        </optgroup>
+                                        <optgroup label={getRoleGroupLabel(true)}>
+                                            {managedRoles
+                                                .filter((role) => role.roleid !== baseRoleId && !compareRoleIds.some((cid, ci) => ci !== idx && cid === role.roleid))
+                                                .map((role) => (
+                                                    <option key={role.roleid} value={role.roleid}>
+                                                        {getRoleDisplayName(role, duplicateRoleNames)}
+                                                    </option>
+                                                ))}
+                                        </optgroup>
+                                    </select>
+                                    {compareRoleIds.length > 1 && (
+                                        <button
+                                            type="button"
+                                            className="remove-slot-btn"
+                                            onClick={() => removeCompareSlot(idx)}
+                                            title="Remove"
+                                            aria-label="Remove compare role"
+                                        >
+                                            <DismissCircleRegular />
+                                        </button>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
 
-                <div className="selector-actions">
-                    {loadingRoles ? (
-                        <Spinner size="tiny" label="Loading roles…" labelPosition="after" />
-                    ) : (
-                        <Button appearance="subtle" icon={<ArrowSyncRegular />} onClick={loadRoles} title="Refresh roles" size="small" />
-                    )}
-                    <Button appearance="primary" onClick={runComparison} disabled={!canCompare || comparing || loadingRoles} size="medium">
-                        {comparing ? <Spinner size="tiny" /> : "Compare"}
-                    </Button>
+                        {compareRoleIds.length < MAX_COMPARE_ROLES && (
+                            <button className="add-slot-btn" onClick={addCompareSlot} disabled={loadingEnvironment || loadingRoles || !selectedSolutionId}>
+                                + Add Role
+                            </button>
+                        )}
+                    </div>
+
+                    <div className="selector-actions">
+                        {loadingEnvironment || loadingRoles ? (
+                            <Spinner size="tiny" label="Loading selections…" labelPosition="after" />
+                        ) : (
+                            <Button appearance="subtle" icon={<ArrowSyncRegular />} onClick={() => void loadEnvironment()} title="Refresh selections" size="small" />
+                        )}
+                        <Button appearance="primary" onClick={runComparison} disabled={!canCompare || comparing || loadingEnvironment || loadingRoles} size="medium">
+                            {comparing ? <Spinner size="tiny" /> : "Compare"}
+                        </Button>
+                    </div>
                 </div>
             </div>
 
@@ -208,24 +508,33 @@ export default function App() {
                 </MessageBar>
             )}
 
-            {/* Filter bar — only visible after comparison */}
             {hasResults && (
                 <div className="filter-bar">
                     <SearchBox
-                        placeholder="Filter by entity or operation…"
+                        placeholder="Filter by entity display name, schema name, or operation…"
                         value={searchTerm}
                         onChange={(_e, data) => setSearchTerm(data.value)}
                         size="small"
                         className="search-box"
                     />
-                    <Checkbox label="Differences only" checked={diffsOnly} onChange={(_e, data) => setDiffsOnly(!!data.checked)} />
+                    <select
+                        className="diff-filter-select"
+                        value={diffFilter}
+                        onChange={(e) => setDiffFilter(e.target.value as DiffFilter)}
+                        aria-label="Row filter"
+                    >
+                        {DIFF_FILTER_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
                     <span className="result-count">
                         {filteredData.length} / {comparisonData.length} privileges
                     </span>
                 </div>
             )}
 
-            {/* Comparison table */}
             {hasResults && (
                 <div className="table-container">
                     <table className="comparison-table">
@@ -250,31 +559,62 @@ export default function App() {
                             </tr>
                         </thead>
                         <tbody>
-                            {sortedEntities.map((entity) =>
-                                groupedData[entity].map((priv, rowIdx) => (
-                                    <tr key={priv.privilegeid} className={rowIdx % 2 === 0 ? "row-even" : "row-odd"}>
-                                        {rowIdx === 0 && (
-                                            <td className="col-entity entity-cell" rowSpan={groupedData[entity].length}>
-                                                {entity}
-                                            </td>
-                                        )}
-                                        <td className="col-operation">{priv.operation}</td>
-                                        {comparedRoleIds.map((rid, ci) => {
-                                            const depth = priv.depthByRole[rid] ?? PrivilegeDepth.None;
-                                            const baseDepth = priv.depthByRole[comparedRoleIds[0]] ?? PrivilegeDepth.None;
-                                            const isDiff = ci > 0 && depth !== baseDepth;
-                                            return (
-                                                <td key={rid} className={`col-role-cell ${ci === 0 ? "col-base-cell" : ""} ${isDiff ? "cell-diff" : ""}`}>
-                                                    <DepthDots depth={depth} />
-                                                </td>
-                                            );
-                                        })}
-                                    </tr>
-                                )),
+                            {categoryGroups.map((category) =>
+                                category.entityGroups.map((group, groupIdx) => {
+                                    const isFirstGroup = groupIdx === 0;
+                                    return group.rows.map((priv, rowIdx) => (
+                                        <Fragment key={priv.privilegeid}>
+                                            {isFirstGroup && rowIdx === 0 && (
+                                                <tr className="category-row">
+                                                    <td className="category-cell" colSpan={columnCount}>
+                                                        {category.label}
+                                                        <span className="category-kind-tag">{category.kind === "table" ? "Tables" : category.kind === "privacy" ? "Privacy" : "Misc"}</span>
+                                                    </td>
+                                                </tr>
+                                            )}
+                                            <tr className={rowIdx % 2 === 0 ? "row-even" : "row-odd"}>
+                                                {rowIdx === 0 && (
+                                                    <td className="col-entity entity-cell" rowSpan={group.rows.length}>
+                                                        <div className="entity-cell-content" title={getEntityLabel(priv)}>
+                                                            <span className="entity-display-name">{priv.entityDisplayName}</span>
+                                                            <span className="entity-schema-name">{priv.entitySchemaName}</span>
+                                                        </div>
+                                                    </td>
+                                                )}
+                                                <td className="col-operation">{priv.operation}</td>
+                                                {comparedRoleIds.map((rid, ci) => {
+                                                    const depth = priv.depthByRole[rid] ?? PrivilegeDepth.None;
+                                                    const baseRank = depthRank(priv.depthByRole[comparedRoleIds[0]]);
+                                                    const rank = depthRank(depth);
+                                                    const direction = ci === 0 ? "none" : rank > baseRank ? "more" : rank < baseRank ? "less" : "none";
+                                                    return (
+                                                        <td key={rid} className={`col-role-cell ${ci === 0 ? "col-base-cell" : ""}`}>
+                                                            <div className="cell-content">
+                                                                <span className="diff-icon-slot">
+                                                                    {direction === "more" && (
+                                                                        <Tooltip content="More permission than base" relationship="label">
+                                                                            <AddCircleFilled className="diff-icon diff-more" aria-label="More permission than base" />
+                                                                        </Tooltip>
+                                                                    )}
+                                                                    {direction === "less" && (
+                                                                        <Tooltip content="Less permission than base" relationship="label">
+                                                                            <SubtractCircleFilled className="diff-icon diff-less" aria-label="Less permission than base" />
+                                                                        </Tooltip>
+                                                                    )}
+                                                                </span>
+                                                                <DepthDots depth={depth} />
+                                                            </div>
+                                                        </td>
+                                                    );
+                                                })}
+                                            </tr>
+                                        </Fragment>
+                                    ));
+                                }),
                             )}
-                            {sortedEntities.length === 0 && (
+                            {categoryGroups.length === 0 && (
                                 <tr>
-                                    <td colSpan={2 + comparedRoleIds.length} className="empty-row">
+                                    <td colSpan={columnCount} className="empty-row">
                                         No privileges match the current filter.
                                     </td>
                                 </tr>
@@ -284,7 +624,6 @@ export default function App() {
                 </div>
             )}
 
-            {/* Legend */}
             {hasResults && (
                 <div className="legend-bar">
                     {(Object.entries(DEPTH_LABELS) as [string, string][]).map(([depth, label]) => (
@@ -294,15 +633,21 @@ export default function App() {
                         </span>
                     ))}
                     <span className="legend-item">
-                        <span className="diff-indicator" />
-                        <span className="legend-label">Differs from base</span>
+                        <AddCircleFilled className="diff-icon diff-more" />
+                        <span className="legend-label">More than base</span>
+                    </span>
+                    <span className="legend-item">
+                        <SubtractCircleFilled className="diff-icon diff-less" />
+                        <span className="legend-label">Less than base</span>
                     </span>
                 </div>
             )}
 
-            {!hasResults && !comparing && !loadingRoles && !error && (
+            {!hasResults && !comparing && !loadingRoles && !loadingEnvironment && !error && (
                 <div className="empty-state">
-                    <p>Select a base role and one or more comparison roles, then click <strong>Compare</strong>.</p>
+                    <p>
+                        Select a solution, then choose a base role and one or more comparison roles before clicking <strong>Compare</strong>.
+                    </p>
                 </div>
             )}
         </div>

--- a/tools/security-role-comparator/src/models/interfaces.ts
+++ b/tools/security-role-comparator/src/models/interfaces.ts
@@ -51,6 +51,21 @@ export interface RoleEditorLayoutItem {
     parentId?: string;
 }
 
+/** Maps the Dataverse PrivilegeType enum (from EntityDefinitions.Privileges) to an operation label. */
+export const PRIVILEGE_TYPE_TO_OPERATION: Record<number, string> = {
+    1: "Create",
+    2: "Read",
+    3: "Write",
+    4: "Delete",
+    5: "Assign",
+    6: "Share",
+    7: "Append",
+    8: "AppendTo",
+};
+
+/** Placeholder "operation" shown for non-table (miscellaneous / privacy) privileges. */
+export const NON_TABLE_OPERATION = "Enable";
+
 export interface Privilege {
     privilegeid: string;
     name: string;
@@ -126,6 +141,15 @@ export const CATEGORY_KIND_ORDER: Record<PrivilegeCategoryKind, number> = {
 /** Standard privilege operations extracted from privilege names */
 export const PRIVILEGE_OPERATIONS = ["Create", "Read", "Write", "Delete", "Append", "AppendTo", "Assign", "Share"] as const;
 export type PrivilegeOperation = (typeof PRIVILEGE_OPERATIONS)[number];
+
+/** Canonical display/sort order for operations, matching the built-in role editor (non-table last). */
+export const OPERATION_SORT_ORDER = [...PRIVILEGE_OPERATIONS, NON_TABLE_OPERATION];
+
+/** Sort rank for an operation; unknown operations sort after all known ones. */
+export function operationRank(operation: string): number {
+    const index = OPERATION_SORT_ORDER.indexOf(operation as (typeof OPERATION_SORT_ORDER)[number]);
+    return index === -1 ? OPERATION_SORT_ORDER.length : index;
+}
 
 /**
  * Operations checked longest-first so more specific prefixes win. Without this, "AppendTo"

--- a/tools/security-role-comparator/src/models/interfaces.ts
+++ b/tools/security-role-comparator/src/models/interfaces.ts
@@ -1,7 +1,54 @@
 export interface SecurityRole {
     roleid: string;
     name: string;
+    solutionid?: string;
+    ismanaged?: boolean;
+    roletemplateid?: string;
+    isautoassigned?: number;
+    issystemgenerated?: boolean;
+    isinherited?: number;
+    canbedeleted?: boolean;
     _businessunitid_value?: string;
+    businessunitName?: string;
+}
+
+export interface DataverseSolution {
+    solutionid: string;
+    friendlyname?: string;
+    uniquename?: string;
+    ismanaged?: boolean;
+    parentsolutionid?: string;
+}
+
+export interface EntityDisplayInfo {
+    logicalName: string;
+    schemaName: string;
+    displayName: string;
+    isCustom: boolean;
+}
+
+/** Kind of privilege grouping category, mirroring the OOB security role editor. */
+export type PrivilegeCategoryKind = "table" | "misc" | "privacy";
+
+/** RoleEditorLayout item types (from the roleeditorlayout_itemtype choice). */
+export enum RoleEditorLayoutItemType {
+    Root = 1,
+    Tab = 2,
+    MiscellaneousSection = 3,
+    Entity = 4,
+    Privilege = 5,
+}
+
+/** A single role-editor-layout item (tab, section, entity, or privilege). */
+export interface RoleEditorLayoutItem {
+    id: string;
+    displayName: string;
+    entityLogicalName?: string;
+    privilegeName?: string;
+    itemType: number;
+    isPrivacyRelated: boolean;
+    tabOrder?: number;
+    parentId?: string;
 }
 
 export interface Privilege {
@@ -33,15 +80,48 @@ export const DEPTH_LABELS: Record<PrivilegeDepth, string> = {
     [PrivilegeDepth.Global]: "Organization",
 };
 
+/** Ordinal rank of a privilege depth (higher = more permission). Handles gaps in the enum values. */
+const DEPTH_RANK: Record<number, number> = {
+    [PrivilegeDepth.None]: 0,
+    [PrivilegeDepth.Basic]: 1,
+    [PrivilegeDepth.Local]: 2,
+    [PrivilegeDepth.Deep]: 3,
+    [PrivilegeDepth.Global]: 4,
+};
+
+/** Normalizes any depth value to its ordinal rank; unknown/missing values are treated as None. */
+export function depthRank(depth: PrivilegeDepth | number | undefined | null): number {
+    if (depth == null) return 0;
+    return DEPTH_RANK[depth] ?? 0;
+}
+
 /** A resolved privilege entry with entity and operation parsed from the privilege name */
 export interface ParsedPrivilege {
     privilegeid: string;
     rawName: string;
-    entity: string;
+    entityLogicalName: string;
+    entitySchemaName: string;
+    entityDisplayName: string;
+    entitySearchText: string;
     operation: string;
+    /** Grouping category derived from the role editor layout (or fallback). */
+    categoryKind: PrivilegeCategoryKind;
+    /** Stable key for the category (layout id or fallback token), used for grouping. */
+    categoryKey: string;
+    /** Localized category label for display. */
+    categoryLabel: string;
+    /** Display order of the category within its kind. */
+    categoryOrder: number;
     /** Depth per role (keyed by roleid) */
     depthByRole: Record<string, PrivilegeDepth>;
 }
+
+/** Sort rank for a category kind: tables first, then miscellaneous, then privacy. */
+export const CATEGORY_KIND_ORDER: Record<PrivilegeCategoryKind, number> = {
+    table: 0,
+    misc: 1,
+    privacy: 2,
+};
 
 /** Standard privilege operations extracted from privilege names */
 export const PRIVILEGE_OPERATIONS = ["Create", "Read", "Write", "Delete", "Append", "AppendTo", "Assign", "Share"] as const;
@@ -49,8 +129,11 @@ export type PrivilegeOperation = (typeof PRIVILEGE_OPERATIONS)[number];
 
 /** Parsed details of a privilege name */
 export interface ParsedPrivilegeName {
-    entity: string;
+    entityToken: string;
+    entityLogicalName: string;
     operation: string;
+    /** True when the privilege name matched a known CRUD-style operation prefix. */
+    isKnownOperation: boolean;
 }
 
 /**
@@ -61,9 +144,19 @@ export function parsePrivilegeName(name: string): ParsedPrivilegeName {
     const stripped = name.startsWith("prv") ? name.substring(3) : name;
     for (const op of PRIVILEGE_OPERATIONS) {
         if (stripped.startsWith(op)) {
-            const entity = stripped.substring(op.length) || "Global";
-            return { entity, operation: op };
+            const entityToken = stripped.substring(op.length) || "Global";
+            return {
+                entityToken,
+                entityLogicalName: entityToken.toLowerCase(),
+                operation: op,
+                isKnownOperation: true,
+            };
         }
     }
-    return { entity: "Miscellaneous", operation: stripped };
+    return {
+        entityToken: stripped,
+        entityLogicalName: stripped.toLowerCase(),
+        operation: stripped,
+        isKnownOperation: false,
+    };
 }

--- a/tools/security-role-comparator/src/models/interfaces.ts
+++ b/tools/security-role-comparator/src/models/interfaces.ts
@@ -127,6 +127,13 @@ export const CATEGORY_KIND_ORDER: Record<PrivilegeCategoryKind, number> = {
 export const PRIVILEGE_OPERATIONS = ["Create", "Read", "Write", "Delete", "Append", "AppendTo", "Assign", "Share"] as const;
 export type PrivilegeOperation = (typeof PRIVILEGE_OPERATIONS)[number];
 
+/**
+ * Operations checked longest-first so more specific prefixes win. Without this, "AppendTo"
+ * privileges (e.g. prvAppendTocai_Allocation) would incorrectly match "Append" and leave a
+ * bogus "Tocai_Allocation" entity instead of "cai_Allocation".
+ */
+const OPERATIONS_BY_LENGTH_DESC = [...PRIVILEGE_OPERATIONS].sort((a, b) => b.length - a.length);
+
 /** Parsed details of a privilege name */
 export interface ParsedPrivilegeName {
     entityToken: string;
@@ -142,7 +149,7 @@ export interface ParsedPrivilegeName {
  */
 export function parsePrivilegeName(name: string): ParsedPrivilegeName {
     const stripped = name.startsWith("prv") ? name.substring(3) : name;
-    for (const op of PRIVILEGE_OPERATIONS) {
+    for (const op of OPERATIONS_BY_LENGTH_DESC) {
         if (stripped.startsWith(op)) {
             const entityToken = stripped.substring(op.length) || "Global";
             return {

--- a/tools/security-role-comparator/src/styles.css
+++ b/tools/security-role-comparator/src/styles.css
@@ -14,6 +14,7 @@
     --bg-row-even: #ffffff;
     --bg-row-odd: #f9fafb;
     --bg-base-col: #eff6ff;
+    --bg-combined-col: #ecfdf5;
     --border: #e5e7eb;
     --text: #111827;
     --text-muted: #6b7280;
@@ -35,6 +36,7 @@ body.dark-theme {
     --bg-row-even: #1f2937;
     --bg-row-odd: #111827;
     --bg-base-col: #1e3a5f;
+    --bg-combined-col: #14342a;
     --border: #374151;
     --text: #f9fafb;
     --text-muted: #9ca3af;
@@ -109,9 +111,9 @@ body {
     display: flex;
     flex-direction: column;
     gap: 3px;
-    min-width: 160px;
+    min-width: 96px;
     max-width: 220px;
-    flex: 1 1 160px;
+    flex: 1 1 96px;
 }
 
 .solution-selector-group {
@@ -161,6 +163,7 @@ body.dark-theme .set-base-link {
 
 .role-select {
     width: 100%;
+    min-width: 0;
     padding: 5px 8px;
     border: 1px solid var(--border);
     border-radius: var(--radius);
@@ -209,9 +212,10 @@ body.dark-theme .set-base-link {
 .compare-slots {
     display: flex;
     gap: 8px;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: flex-end;
-    flex: 1;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .field-note,
@@ -267,10 +271,14 @@ body.dark-theme .set-base-link {
 }
 
 .search-box {
-    max-width: 260px;
+    flex: 0 1 auto;
+    width: 270px;
+    min-width: 200px;
+    max-width: 270px;
 }
 
 .diff-filter-select {
+    width: 161px;
     padding: 5px 8px;
     border: 1px solid var(--border);
     border-radius: var(--radius);
@@ -289,8 +297,9 @@ body.dark-theme .set-base-link {
 }
 
 .multi-filter {
-    min-width: 118px;
-    max-width: 150px;
+    width: 125px !important;
+    min-width: 125px !important;
+    max-width: 125px !important;
 }
 
 /* Compact options in the Groups/Operations listbox to match the ribbon text size. */
@@ -460,6 +469,14 @@ body.dark-theme .set-base-link {
 
 .col-base-cell {
     background: var(--bg-base-col);
+}
+
+.col-combined {
+    background: var(--bg-combined-col);
+}
+
+.col-combined-cell {
+    background: var(--bg-combined-col);
 }
 
 /* Category section header rows */

--- a/tools/security-role-comparator/src/styles.css
+++ b/tools/security-role-comparator/src/styles.css
@@ -14,7 +14,6 @@
     --bg-row-even: #ffffff;
     --bg-row-odd: #f9fafb;
     --bg-base-col: #eff6ff;
-    --bg-diff: #fef9c3;
     --border: #e5e7eb;
     --text: #111827;
     --text-muted: #6b7280;
@@ -36,7 +35,6 @@ body.dark-theme {
     --bg-row-even: #1f2937;
     --bg-row-odd: #111827;
     --bg-base-col: #1e3a5f;
-    --bg-diff: #422006;
     --border: #374151;
     --text: #f9fafb;
     --text-muted: #9ca3af;
@@ -72,7 +70,7 @@ body {
 /* ───────────── Selector bar ───────────── */
 .selector-bar {
     display: flex;
-    align-items: flex-end;
+    align-items: flex-start;
     gap: 12px;
     flex-wrap: wrap;
     padding: 10px 12px;
@@ -83,6 +81,21 @@ body {
     flex-shrink: 0;
 }
 
+.solution-panel {
+    flex: 1 1 100%;
+    display: flex;
+    min-width: 0;
+}
+
+.selector-content {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    flex: 1 1 100%;
+    min-width: 0;
+}
+
 .role-selector-group {
     display: flex;
     flex-direction: column;
@@ -90,6 +103,10 @@ body {
     min-width: 160px;
     max-width: 220px;
     flex: 1 1 160px;
+}
+
+.solution-selector-group {
+    max-width: 320px;
 }
 
 .role-label {
@@ -167,6 +184,16 @@ body.dark-theme .base-label {
     flex: 1;
 }
 
+.field-note,
+.field-meta {
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+.field-meta {
+    margin-top: -1px;
+}
+
 .add-slot-btn {
     padding: 5px 10px;
     font-size: 12px;
@@ -211,6 +238,24 @@ body.dark-theme .base-label {
 
 .search-box {
     max-width: 260px;
+}
+
+.diff-filter-select {
+    padding: 5px 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg);
+    color: var(--text);
+    font-size: 12px;
+    font-family: var(--font);
+    cursor: pointer;
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.diff-filter-select:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
 }
 
 .result-count {
@@ -323,6 +368,24 @@ body.dark-theme .base-label {
     border-right: 1px solid var(--border);
 }
 
+.entity-cell-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.entity-display-name {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.entity-schema-name {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 400;
+}
+
 .comparison-table td {
     padding: 5px 10px;
     vertical-align: middle;
@@ -339,8 +402,72 @@ body.dark-theme .base-label {
     background: var(--bg-base-col);
 }
 
-.cell-diff {
-    background: var(--bg-diff);
+/* Category section header rows */
+.category-row td {
+    padding: 0;
+}
+
+.category-cell {
+    position: sticky;
+    left: 0;
+    background: var(--bg-subtle);
+    font-weight: 700;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text);
+    padding: 6px 10px !important;
+    border-top: 2px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+}
+
+.category-kind-tag {
+    margin-left: 8px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 0 6px;
+}
+
+/* Comparison cell content: directional diff icon + depth dots */
+.cell-content {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    justify-content: center;
+}
+
+.diff-icon-slot {
+    width: 14px;
+    display: inline-flex;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.diff-icon {
+    font-size: 14px;
+    line-height: 1;
+}
+
+.diff-more {
+    color: #16a34a;
+}
+
+.diff-less {
+    color: #dc2626;
+}
+
+body.dark-theme .diff-more {
+    color: #4ade80;
+}
+
+body.dark-theme .diff-less {
+    color: #f87171;
 }
 
 .empty-row {
@@ -387,19 +514,6 @@ body.dark-theme .base-label {
 .legend-label {
     font-size: 11px;
     color: var(--text-muted);
-}
-
-.diff-indicator {
-    width: 16px;
-    height: 12px;
-    border-radius: 3px;
-    background: var(--bg-diff);
-    border: 1px solid #ca8a04;
-    flex-shrink: 0;
-}
-
-body.dark-theme .diff-indicator {
-    border-color: #92400e;
 }
 
 /* ───────────── Empty state ───────────── */

--- a/tools/security-role-comparator/src/styles.css
+++ b/tools/security-role-comparator/src/styles.css
@@ -84,6 +84,18 @@ body {
 .solution-panel {
     flex: 1 1 100%;
     display: flex;
+    align-items: flex-end;
+    gap: 12px;
+    min-width: 0;
+}
+
+.solution-subtext {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    margin-left: auto;
+    text-align: right;
     min-width: 0;
 }
 

--- a/tools/security-role-comparator/src/styles.css
+++ b/tools/security-role-comparator/src/styles.css
@@ -289,7 +289,18 @@ body.dark-theme .set-base-link {
 }
 
 .multi-filter {
+    min-width: 118px;
+    max-width: 150px;
+}
+
+/* Compact options in the Groups/Operations listbox to match the ribbon text size. */
+.filter-listbox {
     min-width: 150px;
+}
+
+.filter-listbox .filter-option {
+    font-size: 12px !important;
+    min-height: 26px;
 }
 
 .result-count {
@@ -308,10 +319,10 @@ body.dark-theme .set-base-link {
 }
 
 .comparison-table {
-    width: 100%;
+    width: auto;
     border-collapse: collapse;
     font-size: 12px;
-    table-layout: fixed;
+    table-layout: auto;
 }
 
 .comparison-table thead {
@@ -336,8 +347,8 @@ body.dark-theme .set-base-link {
 }
 
 .col-entity {
-    width: 160px;
-    min-width: 100px;
+    min-width: 120px;
+    max-width: 360px;
     position: sticky;
     left: 0;
     background: var(--bg-subtle);
@@ -346,14 +357,15 @@ body.dark-theme .set-base-link {
 }
 
 .col-operation {
-    width: 110px;
-    min-width: 80px;
+    min-width: 70px;
+    max-width: 140px;
 }
 
 .col-role {
-    width: 120px;
     min-width: 90px;
+    max-width: 160px;
     text-align: center;
+    border-left: 1px solid var(--border);
 }
 
 .col-base {
@@ -406,17 +418,24 @@ body.dark-theme .set-base-link {
     flex-direction: column;
     gap: 2px;
     min-width: 0;
+    max-width: 100%;
 }
 
 .entity-display-name {
     font-weight: 600;
     color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .entity-schema-name {
     font-size: 11px;
     color: var(--text-muted);
     font-weight: 400;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .comparison-table td {
@@ -430,6 +449,13 @@ body.dark-theme .set-base-link {
 .col-role-cell {
     text-align: center;
     position: relative;
+    border-left: 1px solid var(--border);
+}
+
+/* Close off the right edge of the last compare column. */
+.comparison-table th.col-role:last-child,
+.comparison-table td.col-role-cell:last-child {
+    border-right: 1px solid var(--border);
 }
 
 .col-base-cell {
@@ -508,6 +534,12 @@ body.dark-theme .diff-less {
     font-size: 16px;
     line-height: 1;
     flex-shrink: 0;
+}
+
+/* Compare cells that match the base are de-emphasized so differences stand out. */
+.depth-icon-muted {
+    opacity: 0.4;
+    filter: saturate(0.6);
 }
 
 /* ───────────── Legend ───────────── */

--- a/tools/security-role-comparator/src/styles.css
+++ b/tools/security-role-comparator/src/styles.css
@@ -70,9 +70,8 @@ body {
 /* ───────────── Selector bar ───────────── */
 .selector-bar {
     display: flex;
-    align-items: flex-start;
-    gap: 12px;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 10px;
     padding: 10px 12px;
     background: var(--bg-subtle);
     border: 1px solid var(--border);
@@ -81,8 +80,16 @@ body {
     flex-shrink: 0;
 }
 
+.selector-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 12px;
+    flex-wrap: wrap;
+    width: 100%;
+    min-width: 0;
+}
+
 .solution-panel {
-    flex: 1 1 100%;
     display: flex;
     align-items: flex-end;
     gap: 12px;
@@ -92,20 +99,10 @@ body {
 .solution-subtext {
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
+    align-items: flex-start;
     gap: 2px;
-    margin-left: auto;
-    text-align: right;
     min-width: 0;
-}
-
-.selector-content {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    flex: 1 1 100%;
-    min-width: 0;
+    padding-bottom: 2px;
 }
 
 .role-selector-group {
@@ -134,6 +131,27 @@ body {
 }
 
 body.dark-theme .base-label {
+    color: #60a5fa;
+}
+
+.set-base-link {
+    margin-left: 6px;
+    padding: 0;
+    background: none;
+    border: none;
+    color: #2563eb;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: none;
+    letter-spacing: 0;
+    cursor: pointer;
+}
+
+.set-base-link:hover {
+    text-decoration: underline;
+}
+
+body.dark-theme .set-base-link {
     color: #60a5fa;
 }
 
@@ -270,6 +288,10 @@ body.dark-theme .base-label {
     box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
 }
 
+.multi-filter {
+    min-width: 150px;
+}
+
 .result-count {
     font-size: 11px;
     color: var(--text-muted);
@@ -339,15 +361,14 @@ body.dark-theme .base-label {
 }
 
 .role-col-name {
-    display: block;
-    max-width: 100%;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.base-badge {
-    margin-top: 2px;
+    max-width: 100%;
+    white-space: normal;
+    word-break: break-word;
+    line-height: 1.25;
 }
 
 /* Body rows */
@@ -408,6 +429,7 @@ body.dark-theme .base-label {
 
 .col-role-cell {
     text-align: center;
+    position: relative;
 }
 
 .col-base-cell {
@@ -446,24 +468,17 @@ body.dark-theme .base-label {
     padding: 0 6px;
 }
 
-/* Comparison cell content: directional diff icon + depth dots */
-.cell-content {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    justify-content: center;
-}
-
-.diff-icon-slot {
-    width: 14px;
-    display: inline-flex;
-    justify-content: center;
-    flex-shrink: 0;
-}
-
+/* Comparison cell: depth icon centered, directional diff icon pinned to the left edge. */
 .diff-icon {
     font-size: 14px;
     line-height: 1;
+}
+
+.col-role-cell .diff-icon {
+    position: absolute;
+    left: 6px;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .diff-more {
@@ -488,21 +503,11 @@ body.dark-theme .diff-less {
     padding: 16px;
 }
 
-/* ───────────── Depth dots ───────────── */
-.depth-dots {
-    display: inline-flex;
-    gap: 3px;
-    align-items: center;
-    cursor: default;
-}
-
-.depth-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    display: inline-block;
+/* ───────────── Depth icons ───────────── */
+.depth-icon {
+    font-size: 16px;
+    line-height: 1;
     flex-shrink: 0;
-    transition: background 0.15s;
 }
 
 /* ───────────── Legend ───────────── */

--- a/tools/security-role-comparator/src/utils/dataverseClient.ts
+++ b/tools/security-role-comparator/src/utils/dataverseClient.ts
@@ -87,9 +87,10 @@ export class DataverseConnector {
 
         try {
             const query = `EntityDefinitions(LogicalName='${normalized}')?$select=LogicalName,SchemaName,DisplayName,IsCustomEntity`;
-            const rows = await this.fetchAllRecords(query);
-            const row = rows[0];
-            if (!row) {
+            // A keyed EntityDefinitions request returns a single object (no `value` array),
+            // so read the response directly rather than through fetchAllRecords.
+            const row = await this.executeQuery(query);
+            if (!row || !row.LogicalName) {
                 this.entityDisplayCache.set(normalized, null);
                 return null;
             }
@@ -176,20 +177,41 @@ export class DataverseConnector {
     }
 
     /**
-     * Fetch all solutions from the environment, ordered with unmanaged solutions first.
+     * Fetch the distinct set of solution ids (lowercased) that own at least one security role.
+     * Used to limit the solution picker to solutions that actually contain roles.
+     */
+    async fetchSolutionIdsWithRoles(): Promise<Set<string>> {
+        const query = `roles?$select=solutionid&$top=5000`;
+        const rows = await this.fetchAllRecords(query);
+        const ids = new Set<string>();
+        for (const row of rows) {
+            if (row.solutionid) ids.add(String(row.solutionid).toLowerCase());
+        }
+        return ids;
+    }
+
+    /**
+     * Fetch solutions that contain at least one security role, ordered with unmanaged solutions first.
      */
     async fetchSolutions(): Promise<DataverseSolution[]> {
-        const query = `solutions?$select=solutionid,friendlyname,uniquename,ismanaged,parentsolutionid&$orderby=ismanaged asc,friendlyname asc,uniquename asc&$top=5000`;
-        const rows = await this.fetchAllRecords(query);
-        return rows.map(
-            (row: any): DataverseSolution => ({
-                solutionid: row.solutionid,
-                friendlyname: row.friendlyname,
-                uniquename: row.uniquename,
-                ismanaged: row.ismanaged,
-                parentsolutionid: row.parentsolutionid,
-            }),
-        );
+        const [rows, solutionIdsWithRoles] = await Promise.all([
+            this.fetchAllRecords(
+                `solutions?$select=solutionid,friendlyname,uniquename,ismanaged,parentsolutionid&$orderby=ismanaged asc,friendlyname asc,uniquename asc&$top=5000`,
+            ),
+            this.fetchSolutionIdsWithRoles(),
+        ]);
+
+        return rows
+            .filter((row: any) => row.solutionid && solutionIdsWithRoles.has(String(row.solutionid).toLowerCase()))
+            .map(
+                (row: any): DataverseSolution => ({
+                    solutionid: row.solutionid,
+                    friendlyname: row.friendlyname,
+                    uniquename: row.uniquename,
+                    ismanaged: row.ismanaged,
+                    parentsolutionid: row.parentsolutionid,
+                }),
+            );
     }
 
     /** Fetch all security roles from the environment, sorted by name. */
@@ -199,11 +221,9 @@ export class DataverseConnector {
             "name",
             "solutionid",
             "ismanaged",
-            "roletemplateid",
+            "_roletemplateid_value",
             "isautoassigned",
-            "issystemgenerated",
-            "isinherited",
-            "canbedeleted",
+            "issytemgenerated",
             "_businessunitid_value",
         ];
         const filter = solutionId ? `&$filter=solutionid eq ${this.sanitizeGuid(solutionId)}` : "";
@@ -215,11 +235,10 @@ export class DataverseConnector {
                 name: row.name,
                 solutionid: row.solutionid,
                 ismanaged: row.ismanaged,
-                roletemplateid: row.roletemplateid,
+                roletemplateid: row._roletemplateid_value,
                 isautoassigned: row.isautoassigned,
-                issystemgenerated: row.issystemgenerated,
-                isinherited: row.isinherited,
-                canbedeleted: row.canbedeleted,
+                // NB: the role entity's logical name for this column is misspelled in Dataverse.
+                issystemgenerated: row.issytemgenerated,
                 _businessunitid_value: row._businessunitid_value,
                 businessunitName: row["_businessunitid_value@OData.Community.Display.V1.FormattedValue"],
             }),

--- a/tools/security-role-comparator/src/utils/dataverseClient.ts
+++ b/tools/security-role-comparator/src/utils/dataverseClient.ts
@@ -1,13 +1,229 @@
-import { ParsedPrivilege, Privilege, PrivilegeDepth, RolePrivilegeDepth, SecurityRole, parsePrivilegeName } from "../models/interfaces";
+import {
+    CATEGORY_KIND_ORDER,
+    EntityDisplayInfo,
+    DataverseSolution,
+    ParsedPrivilege,
+    Privilege,
+    PrivilegeCategoryKind,
+    PrivilegeDepth,
+    RoleEditorLayoutItem,
+    RoleEditorLayoutItemType,
+    RolePrivilegeDepth,
+    SecurityRole,
+    parsePrivilegeName,
+} from "../models/interfaces";
+
+/** Resolved role-editor-layout lookups used to categorize privileges. */
+interface RoleEditorLayoutMaps {
+    /** entity logical name (lower) -> parent tab layout item */
+    tabByEntityLogicalName: Map<string, RoleEditorLayoutItem>;
+    /** privilege name (lower) -> privilege layout item */
+    privilegeByName: Map<string, RoleEditorLayoutItem>;
+    /** layout item id -> layout item (for parent lookups) */
+    itemById: Map<string, RoleEditorLayoutItem>;
+    /** whether any usable layout data was found */
+    hasData: boolean;
+}
 
 export class DataverseConnector {
     constructor(_envUrl: string) {}
+    private readonly entityDisplayCache = new Map<string, EntityDisplayInfo | null>();
+    private roleEditorLayoutMaps: RoleEditorLayoutMaps | null = null;
+
+    private toQueryPath(queryOrUrl: string): string {
+        if (!queryOrUrl.startsWith("http")) {
+            return queryOrUrl;
+        }
+
+        const url = new URL(queryOrUrl);
+        const apiRootMatch = url.pathname.match(/\/api\/data\/v[^/]+\/(.*)/i);
+        const relativePath = apiRootMatch?.[1] ?? url.pathname.replace(/^\//, "");
+        return `${relativePath}${url.search}`;
+    }
+
+    private async fetchAllRecords(queryPath: string): Promise<any[]> {
+        const records: any[] = [];
+        let nextQuery = queryPath;
+
+        while (nextQuery) {
+            const result = await this.executeQuery(nextQuery);
+            records.push(...(result.value || []));
+
+            const nextLink = result["@odata.nextLink"] as string | undefined;
+            nextQuery = nextLink ? this.toQueryPath(nextLink) : "";
+        }
+
+        return records;
+    }
+
+    private readLabel(labelValue: any): string | undefined {
+        if (typeof labelValue === "string") {
+            return labelValue;
+        }
+
+        const userLabel = labelValue?.UserLocalizedLabel?.Label;
+        if (typeof userLabel === "string" && userLabel.trim()) {
+            return userLabel;
+        }
+
+        const localizedLabels = labelValue?.LocalizedLabels;
+        if (Array.isArray(localizedLabels)) {
+            const firstLabel = localizedLabels.find((entry) => typeof entry?.Label === "string" && entry.Label.trim());
+            if (firstLabel?.Label) {
+                return firstLabel.Label;
+            }
+        }
+
+        return undefined;
+    }
+
+    async fetchEntityDisplayInfo(logicalName: string): Promise<EntityDisplayInfo | null> {
+        const normalized = logicalName.trim().toLowerCase();
+        if (!normalized) return null;
+
+        if (this.entityDisplayCache.has(normalized)) {
+            return this.entityDisplayCache.get(normalized) ?? null;
+        }
+
+        try {
+            const query = `EntityDefinitions(LogicalName='${normalized}')?$select=LogicalName,SchemaName,DisplayName,IsCustomEntity`;
+            const rows = await this.fetchAllRecords(query);
+            const row = rows[0];
+            if (!row) {
+                this.entityDisplayCache.set(normalized, null);
+                return null;
+            }
+
+            const info: EntityDisplayInfo = {
+                logicalName: (row.LogicalName || normalized).toLowerCase(),
+                schemaName: row.SchemaName || row.LogicalName || normalized,
+                displayName: this.readLabel(row.DisplayName) || row.SchemaName || row.LogicalName || normalized,
+                isCustom: row.IsCustomEntity === true,
+            };
+
+            this.entityDisplayCache.set(normalized, info);
+            return info;
+        } catch {
+            this.entityDisplayCache.set(normalized, null);
+            return null;
+        }
+    }
+
+    /**
+     * Fetch and cache the role editor layout that drives the OOB security role editor grouping
+     * (tabs like Core Records / Business Management, plus Miscellaneous and Privacy sections).
+     * Degrades gracefully to an empty map set when the table is unavailable.
+     */
+    async fetchRoleEditorLayoutMaps(): Promise<RoleEditorLayoutMaps> {
+        if (this.roleEditorLayoutMaps) {
+            return this.roleEditorLayoutMaps;
+        }
+
+        const emptyMaps: RoleEditorLayoutMaps = {
+            tabByEntityLogicalName: new Map(),
+            privilegeByName: new Map(),
+            itemById: new Map(),
+            hasData: false,
+        };
+
+        try {
+            const query = `roleeditorlayouts?$select=roleeditorlayoutid,displayname,entitylogicalname,privilegename,itemtype,isprivacyrelated,taborder,_roleeditorlayouthierarchyid_value&$top=5000`;
+            const rows = await this.fetchAllRecords(query);
+
+            const items: RoleEditorLayoutItem[] = rows.map((row: any) => ({
+                id: row.roleeditorlayoutid,
+                displayName: row.displayname || "",
+                entityLogicalName: row.entitylogicalname || undefined,
+                privilegeName: row.privilegename || undefined,
+                itemType: row.itemtype,
+                isPrivacyRelated: row.isprivacyrelated === true,
+                tabOrder: typeof row.taborder === "number" ? row.taborder : undefined,
+                parentId: row._roleeditorlayouthierarchyid_value || undefined,
+            }));
+
+            const itemById = new Map<string, RoleEditorLayoutItem>();
+            for (const item of items) {
+                itemById.set(item.id, item);
+            }
+
+            const tabByEntityLogicalName = new Map<string, RoleEditorLayoutItem>();
+            const privilegeByName = new Map<string, RoleEditorLayoutItem>();
+
+            for (const item of items) {
+                if (item.itemType === RoleEditorLayoutItemType.Entity && item.entityLogicalName) {
+                    tabByEntityLogicalName.set(item.entityLogicalName.toLowerCase(), item);
+                } else if (item.itemType === RoleEditorLayoutItemType.Privilege && item.privilegeName) {
+                    // Prefer keeping the first mapping; privacy-related wins if a duplicate exists.
+                    const key = item.privilegeName.toLowerCase();
+                    const existing = privilegeByName.get(key);
+                    if (!existing || (!existing.isPrivacyRelated && item.isPrivacyRelated)) {
+                        privilegeByName.set(key, item);
+                    }
+                }
+            }
+
+            this.roleEditorLayoutMaps = {
+                tabByEntityLogicalName,
+                privilegeByName,
+                itemById,
+                hasData: items.length > 0,
+            };
+            return this.roleEditorLayoutMaps;
+        } catch {
+            this.roleEditorLayoutMaps = emptyMaps;
+            return emptyMaps;
+        }
+    }
+
+    /**
+     * Fetch all solutions from the environment, ordered with unmanaged solutions first.
+     */
+    async fetchSolutions(): Promise<DataverseSolution[]> {
+        const query = `solutions?$select=solutionid,friendlyname,uniquename,ismanaged,parentsolutionid&$orderby=ismanaged asc,friendlyname asc,uniquename asc&$top=5000`;
+        const rows = await this.fetchAllRecords(query);
+        return rows.map(
+            (row: any): DataverseSolution => ({
+                solutionid: row.solutionid,
+                friendlyname: row.friendlyname,
+                uniquename: row.uniquename,
+                ismanaged: row.ismanaged,
+                parentsolutionid: row.parentsolutionid,
+            }),
+        );
+    }
 
     /** Fetch all security roles from the environment, sorted by name. */
-    async fetchRoles(): Promise<SecurityRole[]> {
-        const query = `roles?$select=roleid,name,_businessunitid_value&$orderby=name asc`;
-        const result = await this.executeQuery(query);
-        return (result.value || []) as SecurityRole[];
+    async fetchRoles(solutionId?: string): Promise<SecurityRole[]> {
+        const selects = [
+            "roleid",
+            "name",
+            "solutionid",
+            "ismanaged",
+            "roletemplateid",
+            "isautoassigned",
+            "issystemgenerated",
+            "isinherited",
+            "canbedeleted",
+            "_businessunitid_value",
+        ];
+        const filter = solutionId ? `&$filter=solutionid eq ${this.sanitizeGuid(solutionId)}` : "";
+        const query = `roles?$select=${selects.join(",")}${filter}&$orderby=ismanaged asc,name asc&$top=5000`;
+        const rows = await this.fetchAllRecords(query);
+        return rows.map(
+            (row: any): SecurityRole => ({
+                roleid: row.roleid,
+                name: row.name,
+                solutionid: row.solutionid,
+                ismanaged: row.ismanaged,
+                roletemplateid: row.roletemplateid,
+                isautoassigned: row.isautoassigned,
+                issystemgenerated: row.issystemgenerated,
+                isinherited: row.isinherited,
+                canbedeleted: row.canbedeleted,
+                _businessunitid_value: row._businessunitid_value,
+                businessunitName: row["_businessunitid_value@OData.Community.Display.V1.FormattedValue"],
+            }),
+        );
     }
 
     /**
@@ -16,9 +232,9 @@ export class DataverseConnector {
      */
     async fetchRolePrivileges(roleId: string): Promise<Privilege[]> {
         const sanitizedId = this.sanitizeGuid(roleId);
-        const query = `roles(${sanitizedId})/roleprivileges_association?$select=privilegeid,name,accessright`;
-        const result = await this.executeQuery(query);
-        return (result.value || []) as Privilege[];
+        const query = `roles(${sanitizedId})/roleprivileges_association?$select=privilegeid,name,accessright&$top=5000`;
+        const rows = await this.fetchAllRecords(query);
+        return rows as Privilege[];
     }
 
     /**
@@ -28,9 +244,8 @@ export class DataverseConnector {
     async fetchRolePrivilegeDepths(roleId: string): Promise<RolePrivilegeDepth[]> {
         try {
             const sanitizedId = this.sanitizeGuid(roleId);
-            const query = `roleprivilegesbase?$filter=_roleid_value eq ${sanitizedId}&$select=_privilegeid_value,privilegedepthid`;
-            const result = await this.executeQuery(query);
-            const rows = (result.value || []) as Array<{ _privilegeid_value: string; privilegedepthid: number }>;
+            const query = `roleprivilegesbase?$filter=_roleid_value eq ${sanitizedId}&$select=_privilegeid_value,privilegedepthid&$top=5000`;
+            const rows = (await this.fetchAllRecords(query)) as Array<{ _privilegeid_value: string; privilegedepthid: number }>;
             return rows.map((row) => ({
                 privilegeid: row._privilegeid_value,
                 privilegedepthid: row.privilegedepthid as PrivilegeDepth,
@@ -72,11 +287,47 @@ export class DataverseConnector {
             }
         }
 
+        // Only table (CRUD-style) privileges resolve to an entity definition; skip metadata
+        // lookups for miscellaneous privileges to avoid a flood of 404s.
+        const uniqueEntityLogicalNames = Array.from(
+            new Set(
+                Array.from(privilegeMap.values())
+                    .map((priv) => parsePrivilegeName(priv.name))
+                    .filter((parsed) => parsed.isKnownOperation)
+                    .map((parsed) => parsed.entityLogicalName),
+            ),
+        );
+        const [layoutMaps, entityInfoEntries] = await Promise.all([
+            this.fetchRoleEditorLayoutMaps(),
+            Promise.all(uniqueEntityLogicalNames.map(async (logicalName) => [logicalName, await this.fetchEntityDisplayInfo(logicalName)] as const)),
+        ]);
+        const entityInfoByLogicalName = new Map<string, EntityDisplayInfo | null>(entityInfoEntries);
+
         // Build the comparison list
         const result: ParsedPrivilege[] = [];
         for (const [privilegeid, priv] of privilegeMap) {
             const parsed = parsePrivilegeName(priv.name);
             const depthByRole: Record<string, PrivilegeDepth> = {};
+            const entityInfo = entityInfoByLogicalName.get(parsed.entityLogicalName) ?? null;
+            const category = this.resolveCategory(priv.name, parsed, entityInfo, layoutMaps);
+
+            let entityLogicalName: string;
+            let entitySchemaName: string;
+            let entityDisplayName: string;
+            let operation: string;
+
+            if (category.kind === "table") {
+                entityLogicalName = entityInfo?.logicalName ?? parsed.entityLogicalName;
+                entitySchemaName = entityInfo?.schemaName ?? parsed.entityToken;
+                entityDisplayName = entityInfo?.displayName ?? category.layoutDisplayName ?? parsed.entityToken;
+                operation = parsed.operation;
+            } else {
+                // Miscellaneous / privacy privileges have no entity/operation split; each is its own row.
+                entityLogicalName = priv.name.toLowerCase();
+                entitySchemaName = priv.name;
+                entityDisplayName = category.layoutDisplayName || parsed.entityToken || priv.name;
+                operation = "";
+            }
 
             for (const { roleId, privileges, depthMap } of roleData) {
                 const hasPriv = privileges.some((p) => p.privilegeid === privilegeid);
@@ -92,20 +343,74 @@ export class DataverseConnector {
             result.push({
                 privilegeid,
                 rawName: priv.name,
-                entity: parsed.entity,
-                operation: parsed.operation,
+                entityLogicalName,
+                entitySchemaName,
+                entityDisplayName,
+                entitySearchText: [entityDisplayName, entitySchemaName, entityLogicalName, parsed.entityToken, priv.name, category.label].join(" ").toLowerCase(),
+                operation,
+                categoryKind: category.kind,
+                categoryKey: category.key,
+                categoryLabel: category.label,
+                categoryOrder: category.order,
                 depthByRole,
             });
         }
 
-        // Sort: by entity name, then by operation
+        // Sort: by category (kind, then order, then label), then entity, then operation.
         result.sort((a, b) => {
-            const entityCmp = a.entity.localeCompare(b.entity);
+            const kindCmp = CATEGORY_KIND_ORDER[a.categoryKind] - CATEGORY_KIND_ORDER[b.categoryKind];
+            if (kindCmp !== 0) return kindCmp;
+            const orderCmp = a.categoryOrder - b.categoryOrder;
+            if (orderCmp !== 0) return orderCmp;
+            const labelCmp = a.categoryLabel.localeCompare(b.categoryLabel);
+            if (labelCmp !== 0) return labelCmp;
+            const entityCmp = a.entityDisplayName.localeCompare(b.entityDisplayName);
             if (entityCmp !== 0) return entityCmp;
+            const schemaCmp = a.entitySchemaName.localeCompare(b.entitySchemaName);
+            if (schemaCmp !== 0) return schemaCmp;
             return a.operation.localeCompare(b.operation);
         });
 
         return result;
+    }
+
+    /**
+     * Determine the OOB-style grouping category for a privilege using the role editor layout,
+     * falling back to entity-definition metadata (custom vs standard tables) when the layout
+     * doesn't cover the privilege.
+     */
+    private resolveCategory(
+        privilegeName: string,
+        parsed: ReturnType<typeof parsePrivilegeName>,
+        entityInfo: EntityDisplayInfo | null,
+        maps: RoleEditorLayoutMaps,
+    ): { kind: PrivilegeCategoryKind; key: string; label: string; order: number; layoutDisplayName?: string } {
+        // 1. Miscellaneous / privacy privileges are listed explicitly in the layout.
+        const privItem = maps.privilegeByName.get(privilegeName.toLowerCase());
+        if (privItem) {
+            const kind: PrivilegeCategoryKind = privItem.isPrivacyRelated ? "privacy" : "misc";
+            const section = privItem.parentId ? maps.itemById.get(privItem.parentId) : undefined;
+            const label = section?.displayName || (kind === "privacy" ? "Privacy Related Privileges" : "Miscellaneous Privileges");
+            return { kind, key: privItem.parentId || kind, label, order: section?.tabOrder ?? 0, layoutDisplayName: privItem.displayName };
+        }
+
+        // 2. Table privileges are grouped under their entity's parent tab.
+        const entityItem = maps.tabByEntityLogicalName.get(parsed.entityLogicalName);
+        if (entityItem) {
+            const tab = entityItem.parentId ? maps.itemById.get(entityItem.parentId) : undefined;
+            const label = tab?.displayName || "Tables";
+            return { kind: "table", key: entityItem.parentId || "tables", label, order: tab?.tabOrder ?? 900, layoutDisplayName: entityItem.displayName };
+        }
+
+        // 3. Fallback: a resolved entity definition -> table, split custom vs standard.
+        if (entityInfo) {
+            return entityInfo.isCustom
+                ? { kind: "table", key: "custom-tables", label: "Custom Tables", order: 902 }
+                : { kind: "table", key: "standard-tables", label: "Standard Tables", order: 901 };
+        }
+
+        // 4. Fallback: unclassified non-table privilege.
+        return { kind: "misc", key: "misc", label: "Miscellaneous Privileges", order: 999 };
     }
 
     private sanitizeGuid(rawValue: string): string {
@@ -121,7 +426,7 @@ export class DataverseConnector {
         if (!window.dataverseAPI) {
             throw new Error("Dataverse API not available");
         }
-        return await window.dataverseAPI.queryData(queryPath);
+        return await window.dataverseAPI.queryData(this.toQueryPath(queryPath));
     }
 
     static async showMessage(title: string, message: string, severity: "success" | "error" | "warning" | "info"): Promise<void> {

--- a/tools/security-role-comparator/src/utils/dataverseClient.ts
+++ b/tools/security-role-comparator/src/utils/dataverseClient.ts
@@ -2,10 +2,13 @@ import {
     CATEGORY_KIND_ORDER,
     EntityDisplayInfo,
     DataverseSolution,
+    NON_TABLE_OPERATION,
+    operationRank,
     ParsedPrivilege,
     Privilege,
     PrivilegeCategoryKind,
     PrivilegeDepth,
+    PRIVILEGE_TYPE_TO_OPERATION,
     RoleEditorLayoutItem,
     RoleEditorLayoutItemType,
     RolePrivilegeDepth,
@@ -25,10 +28,26 @@ interface RoleEditorLayoutMaps {
     hasData: boolean;
 }
 
+/** Authoritative privilege -> entity + operation index built from EntityDefinitions.Privileges. */
+interface EntityPrivilegeIndex {
+    byPrivilegeId: Map<string, EntityDisplayInfo>;
+    byPrivilegeName: Map<string, EntityDisplayInfo>;
+    operationByPrivilegeId: Map<string, string>;
+    operationByPrivilegeName: Map<string, string>;
+    /** True when the bulk metadata query returned at least one privilege mapping. */
+    hasData: boolean;
+}
+
+/** Normalizes a GUID/name key for map lookups (lowercase, strip braces/whitespace). */
+function normalizeKey(value: string): string {
+    return value.trim().toLowerCase().replace(/[{}]/g, "");
+}
+
 export class DataverseConnector {
     constructor(_envUrl: string) {}
     private readonly entityDisplayCache = new Map<string, EntityDisplayInfo | null>();
     private roleEditorLayoutMaps: RoleEditorLayoutMaps | null = null;
+    private entityPrivilegeIndex: EntityPrivilegeIndex | null = null;
     private allRolesCache: SecurityRole[] | null = null;
     private roleIdsBySolutionCache: Map<string, Set<string>> | null = null;
 
@@ -110,6 +129,68 @@ export class DataverseConnector {
             this.entityDisplayCache.set(normalized, null);
             return null;
         }
+    }
+
+    /**
+     * Build (and cache) an authoritative privilege -> entity + operation index from the metadata
+     * `EntityDefinitions.Privileges` collection. This maps every table privilege to its owning
+     * entity and operation regardless of how the privilege name is spelled, which is essential for
+     * tables whose privilege names don't match their logical name (e.g. prvReadUser -> systemuser,
+     * prvReadActivity -> activitypointer).
+     */
+    async fetchEntityPrivilegeIndex(): Promise<EntityPrivilegeIndex> {
+        if (this.entityPrivilegeIndex) {
+            return this.entityPrivilegeIndex;
+        }
+
+        const index: EntityPrivilegeIndex = {
+            byPrivilegeId: new Map(),
+            byPrivilegeName: new Map(),
+            operationByPrivilegeId: new Map(),
+            operationByPrivilegeName: new Map(),
+            hasData: false,
+        };
+
+        try {
+            const rows = await this.fetchAllRecords(
+                `EntityDefinitions?$select=LogicalName,SchemaName,DisplayName,IsCustomEntity,Privileges&LabelLanguages=1033`,
+            );
+            for (const row of rows) {
+                const logicalName = (row.LogicalName || "").toLowerCase();
+                if (!logicalName) continue;
+                const info: EntityDisplayInfo = {
+                    logicalName,
+                    schemaName: row.SchemaName || row.LogicalName || logicalName,
+                    displayName: this.readLabel(row.DisplayName) || row.SchemaName || row.LogicalName || logicalName,
+                    isCustom: row.IsCustomEntity === true,
+                };
+
+                const privileges = Array.isArray(row.Privileges) ? row.Privileges : [];
+                for (const priv of privileges) {
+                    // The Web API may return PrivilegeType as its enum string ("Read") or numeric value.
+                    const rawType = priv.PrivilegeType;
+                    const operation = typeof rawType === "string" ? rawType : PRIVILEGE_TYPE_TO_OPERATION[Number(rawType)];
+                    const validOperation = operation && operation !== "None" ? operation : undefined;
+
+                    if (priv.PrivilegeId) {
+                        const id = normalizeKey(String(priv.PrivilegeId));
+                        index.byPrivilegeId.set(id, info);
+                        if (validOperation) index.operationByPrivilegeId.set(id, validOperation);
+                    }
+                    if (priv.Name) {
+                        const name = normalizeKey(String(priv.Name));
+                        index.byPrivilegeName.set(name, info);
+                        if (validOperation) index.operationByPrivilegeName.set(name, validOperation);
+                    }
+                }
+            }
+        } catch {
+            // Metadata unavailable; index stays empty and callers fall back to per-entity lookups.
+        }
+
+        index.hasData = index.byPrivilegeId.size > 0 || index.byPrivilegeName.size > 0;
+        this.entityPrivilegeIndex = index;
+        return index;
     }
 
     /**
@@ -364,46 +445,57 @@ export class DataverseConnector {
             }
         }
 
-        // Only table (CRUD-style) privileges resolve to an entity definition; skip metadata
-        // lookups for miscellaneous privileges to avoid a flood of 404s.
-        const uniqueEntityLogicalNames = Array.from(
-            new Set(
-                Array.from(privilegeMap.values())
-                    .map((priv) => parsePrivilegeName(priv.name))
-                    .filter((parsed) => parsed.isKnownOperation)
-                    .map((parsed) => parsed.entityLogicalName),
-            ),
-        );
-        const [layoutMaps, entityInfoEntries] = await Promise.all([
-            this.fetchRoleEditorLayoutMaps(),
-            Promise.all(uniqueEntityLogicalNames.map(async (logicalName) => [logicalName, await this.fetchEntityDisplayInfo(logicalName)] as const)),
-        ]);
-        const entityInfoByLogicalName = new Map<string, EntityDisplayInfo | null>(entityInfoEntries);
+        const [layoutMaps, privIndex] = await Promise.all([this.fetchRoleEditorLayoutMaps(), this.fetchEntityPrivilegeIndex()]);
+
+        // Fallback: if the bulk privilege index is unavailable, resolve table entities the old way
+        // (per-entity metadata lookup keyed on the logical name parsed from the privilege name) so
+        // standard tables still classify correctly instead of collapsing into Miscellaneous.
+        const fallbackEntityByLogicalName = new Map<string, EntityDisplayInfo | null>();
+        if (!privIndex.hasData) {
+            const uniqueLogicalNames = Array.from(
+                new Set(
+                    Array.from(privilegeMap.values())
+                        .map((priv) => parsePrivilegeName(priv.name))
+                        .filter((parsed) => parsed.isKnownOperation)
+                        .map((parsed) => parsed.entityLogicalName),
+                ),
+            );
+            const entries = await Promise.all(uniqueLogicalNames.map(async (name) => [name, await this.fetchEntityDisplayInfo(name)] as const));
+            for (const [name, info] of entries) fallbackEntityByLogicalName.set(name, info);
+        }
 
         // Build the comparison list
         const result: ParsedPrivilege[] = [];
         for (const [privilegeid, priv] of privilegeMap) {
             const parsed = parsePrivilegeName(priv.name);
             const depthByRole: Record<string, PrivilegeDepth> = {};
-            const entityInfo = entityInfoByLogicalName.get(parsed.entityLogicalName) ?? null;
-            const category = this.resolveCategory(priv.name, parsed, entityInfo, layoutMaps);
+
+            const idKey = normalizeKey(privilegeid);
+            const nameKey = normalizeKey(priv.name);
+            // Resolve the entity + operation authoritatively from metadata; fall back per-entity.
+            const entityInfo =
+                privIndex.byPrivilegeId.get(idKey) ??
+                privIndex.byPrivilegeName.get(nameKey) ??
+                (parsed.isKnownOperation ? fallbackEntityByLogicalName.get(parsed.entityLogicalName) ?? null : null);
+            const indexOperation = privIndex.operationByPrivilegeId.get(idKey) ?? privIndex.operationByPrivilegeName.get(nameKey);
+            const category = this.resolveCategory(priv.name, entityInfo?.logicalName ?? null, entityInfo, layoutMaps);
 
             let entityLogicalName: string;
             let entitySchemaName: string;
             let entityDisplayName: string;
             let operation: string;
 
-            if (category.kind === "table") {
-                entityLogicalName = entityInfo?.logicalName ?? parsed.entityLogicalName;
-                entitySchemaName = entityInfo?.schemaName ?? parsed.entityToken;
-                entityDisplayName = entityInfo?.displayName ?? category.layoutDisplayName ?? parsed.entityToken;
-                operation = parsed.operation;
+            if (entityInfo) {
+                entityLogicalName = entityInfo.logicalName;
+                entitySchemaName = entityInfo.schemaName;
+                entityDisplayName = entityInfo.displayName;
+                operation = indexOperation ?? (parsed.isKnownOperation ? parsed.operation : NON_TABLE_OPERATION);
             } else {
                 // Miscellaneous / privacy privileges have no entity/operation split; each is its own row.
                 entityLogicalName = priv.name.toLowerCase();
                 entitySchemaName = priv.name;
                 entityDisplayName = category.layoutDisplayName || parsed.entityToken || priv.name;
-                operation = "";
+                operation = NON_TABLE_OPERATION;
             }
 
             for (const { roleId, privileges, depthMap } of roleData) {
@@ -445,24 +537,38 @@ export class DataverseConnector {
             if (entityCmp !== 0) return entityCmp;
             const schemaCmp = a.entitySchemaName.localeCompare(b.entitySchemaName);
             if (schemaCmp !== 0) return schemaCmp;
-            return a.operation.localeCompare(b.operation);
+            return operationRank(a.operation) - operationRank(b.operation);
         });
 
         return result;
     }
 
     /**
-     * Determine the OOB-style grouping category for a privilege using the role editor layout,
-     * falling back to entity-definition metadata (custom vs standard tables) when the layout
-     * doesn't cover the privilege.
+     * Determine the OOB-style grouping category for a privilege. Table privileges (those that
+     * resolve to an entity) group under their entity's role-editor tab; miscellaneous / privacy
+     * privileges group under their role-editor section.
      */
     private resolveCategory(
         privilegeName: string,
-        parsed: ReturnType<typeof parsePrivilegeName>,
+        entityLogicalName: string | null,
         entityInfo: EntityDisplayInfo | null,
         maps: RoleEditorLayoutMaps,
     ): { kind: PrivilegeCategoryKind; key: string; label: string; order: number; layoutDisplayName?: string } {
-        // 1. Miscellaneous / privacy privileges are listed explicitly in the layout.
+        // 1. Table privileges group under their entity's parent tab.
+        if (entityLogicalName) {
+            const entityItem = maps.tabByEntityLogicalName.get(entityLogicalName);
+            if (entityItem) {
+                const tab = entityItem.parentId ? maps.itemById.get(entityItem.parentId) : undefined;
+                const label = tab?.displayName || "Tables";
+                return { kind: "table", key: entityItem.parentId || "tables", label, order: tab?.tabOrder ?? 900, layoutDisplayName: entityItem.displayName };
+            }
+            // Fallback: entity known but not in the layout -> split custom vs standard tables.
+            return entityInfo?.isCustom
+                ? { kind: "table", key: "custom-tables", label: "Custom Tables", order: 902 }
+                : { kind: "table", key: "standard-tables", label: "Standard Tables", order: 901 };
+        }
+
+        // 2. Miscellaneous / privacy privileges are listed explicitly in the layout.
         const privItem = maps.privilegeByName.get(privilegeName.toLowerCase());
         if (privItem) {
             const kind: PrivilegeCategoryKind = privItem.isPrivacyRelated ? "privacy" : "misc";
@@ -471,22 +577,7 @@ export class DataverseConnector {
             return { kind, key: privItem.parentId || kind, label, order: section?.tabOrder ?? 0, layoutDisplayName: privItem.displayName };
         }
 
-        // 2. Table privileges are grouped under their entity's parent tab.
-        const entityItem = maps.tabByEntityLogicalName.get(parsed.entityLogicalName);
-        if (entityItem) {
-            const tab = entityItem.parentId ? maps.itemById.get(entityItem.parentId) : undefined;
-            const label = tab?.displayName || "Tables";
-            return { kind: "table", key: entityItem.parentId || "tables", label, order: tab?.tabOrder ?? 900, layoutDisplayName: entityItem.displayName };
-        }
-
-        // 3. Fallback: a resolved entity definition -> table, split custom vs standard.
-        if (entityInfo) {
-            return entityInfo.isCustom
-                ? { kind: "table", key: "custom-tables", label: "Custom Tables", order: 902 }
-                : { kind: "table", key: "standard-tables", label: "Standard Tables", order: 901 };
-        }
-
-        // 4. Fallback: unclassified non-table privilege.
+        // 3. Fallback: unclassified non-table privilege.
         return { kind: "misc", key: "misc", label: "Miscellaneous Privileges", order: 999 };
     }
 

--- a/tools/security-role-comparator/src/utils/dataverseClient.ts
+++ b/tools/security-role-comparator/src/utils/dataverseClient.ts
@@ -29,6 +29,8 @@ export class DataverseConnector {
     constructor(_envUrl: string) {}
     private readonly entityDisplayCache = new Map<string, EntityDisplayInfo | null>();
     private roleEditorLayoutMaps: RoleEditorLayoutMaps | null = null;
+    private allRolesCache: SecurityRole[] | null = null;
+    private roleIdsBySolutionCache: Map<string, Set<string>> | null = null;
 
     private toQueryPath(queryOrUrl: string): string {
         if (!queryOrUrl.startsWith("http")) {
@@ -177,45 +179,58 @@ export class DataverseConnector {
     }
 
     /**
-     * Fetch the distinct set of solution ids (lowercased) that own at least one security role.
-     * Used to limit the solution picker to solutions that actually contain roles.
+     * Map every solution to the set of security-role ids it contains. Role membership is unioned
+     * from two sources:
+     *  1. solutioncomponent (component type 20 = Role) — records roles explicitly added to a
+     *     solution, which is how a role appears in unmanaged solutions other than the one that
+     *     created it.
+     *  2. role.solutionid — the solution that created the role (usually the default/Active
+     *     solution), which solutioncomponent may not enumerate.
      */
-    async fetchSolutionIdsWithRoles(): Promise<Set<string>> {
-        const query = `roles?$select=solutionid&$top=5000`;
-        const rows = await this.fetchAllRecords(query);
-        const ids = new Set<string>();
-        for (const row of rows) {
-            if (row.solutionid) ids.add(String(row.solutionid).toLowerCase());
+    async fetchRoleIdsBySolution(): Promise<Map<string, Set<string>>> {
+        if (this.roleIdsBySolutionCache) {
+            return this.roleIdsBySolutionCache;
         }
-        return ids;
+
+        const map = new Map<string, Set<string>>();
+        const add = (solutionId?: string, roleId?: string) => {
+            const s = solutionId ? String(solutionId).toLowerCase() : "";
+            const r = roleId ? String(roleId).toLowerCase() : "";
+            if (!s || !r) return;
+            let set = map.get(s);
+            if (!set) {
+                set = new Set<string>();
+                map.set(s, set);
+            }
+            set.add(r);
+        };
+
+        // Source 1: explicit solution components (componenttype 20 = Role).
+        try {
+            const rows = await this.fetchAllRecords(`solutioncomponents?$select=objectid,_solutionid_value&$filter=componenttype eq 20&$top=5000`);
+            for (const row of rows) add(row._solutionid_value, row.objectid);
+        } catch {
+            // solutioncomponents may not be queryable; fall through to owning-solution mapping.
+        }
+
+        // Source 2: each role's owning solution.
+        try {
+            const allRoles = await this.fetchAllRolesRaw();
+            for (const role of allRoles) add(role.solutionid, role.roleid);
+        } catch {
+            // ignore; map may still contain source-1 data
+        }
+
+        this.roleIdsBySolutionCache = map;
+        return map;
     }
 
-    /**
-     * Fetch solutions that contain at least one security role, ordered with unmanaged solutions first.
-     */
-    async fetchSolutions(): Promise<DataverseSolution[]> {
-        const [rows, solutionIdsWithRoles] = await Promise.all([
-            this.fetchAllRecords(
-                `solutions?$select=solutionid,friendlyname,uniquename,ismanaged,parentsolutionid&$orderby=ismanaged asc,friendlyname asc,uniquename asc&$top=5000`,
-            ),
-            this.fetchSolutionIdsWithRoles(),
-        ]);
+    /** Fetch every security role in the environment (cached), sorted by managed state then name. */
+    private async fetchAllRolesRaw(): Promise<SecurityRole[]> {
+        if (this.allRolesCache) {
+            return this.allRolesCache;
+        }
 
-        return rows
-            .filter((row: any) => row.solutionid && solutionIdsWithRoles.has(String(row.solutionid).toLowerCase()))
-            .map(
-                (row: any): DataverseSolution => ({
-                    solutionid: row.solutionid,
-                    friendlyname: row.friendlyname,
-                    uniquename: row.uniquename,
-                    ismanaged: row.ismanaged,
-                    parentsolutionid: row.parentsolutionid,
-                }),
-            );
-    }
-
-    /** Fetch all security roles from the environment, sorted by name. */
-    async fetchRoles(solutionId?: string): Promise<SecurityRole[]> {
         const selects = [
             "roleid",
             "name",
@@ -226,10 +241,9 @@ export class DataverseConnector {
             "issytemgenerated",
             "_businessunitid_value",
         ];
-        const filter = solutionId ? `&$filter=solutionid eq ${this.sanitizeGuid(solutionId)}` : "";
-        const query = `roles?$select=${selects.join(",")}${filter}&$orderby=ismanaged asc,name asc&$top=5000`;
+        const query = `roles?$select=${selects.join(",")}&$orderby=ismanaged asc,name asc&$top=5000`;
         const rows = await this.fetchAllRecords(query);
-        return rows.map(
+        this.allRolesCache = rows.map(
             (row: any): SecurityRole => ({
                 roleid: row.roleid,
                 name: row.name,
@@ -243,6 +257,50 @@ export class DataverseConnector {
                 businessunitName: row["_businessunitid_value@OData.Community.Display.V1.FormattedValue"],
             }),
         );
+        return this.allRolesCache;
+    }
+
+    /**
+     * Fetch solutions that contain at least one security role (via solutioncomponent membership),
+     * ordered with unmanaged solutions first.
+     */
+    async fetchSolutions(): Promise<DataverseSolution[]> {
+        const [rows, roleIdsBySolution] = await Promise.all([
+            this.fetchAllRecords(
+                `solutions?$select=solutionid,friendlyname,uniquename,ismanaged,parentsolutionid&$orderby=ismanaged asc,friendlyname asc,uniquename asc&$top=5000`,
+            ),
+            this.fetchRoleIdsBySolution(),
+        ]);
+
+        return rows
+            .filter((row: any) => {
+                const id = row.solutionid ? String(row.solutionid).toLowerCase() : "";
+                return id && (roleIdsBySolution.get(id)?.size ?? 0) > 0;
+            })
+            .map(
+                (row: any): DataverseSolution => ({
+                    solutionid: row.solutionid,
+                    friendlyname: row.friendlyname,
+                    uniquename: row.uniquename,
+                    ismanaged: row.ismanaged,
+                    parentsolutionid: row.parentsolutionid,
+                }),
+            );
+    }
+
+    /** Fetch the security roles contained in a solution (via solutioncomponent membership). */
+    async fetchRoles(solutionId?: string): Promise<SecurityRole[]> {
+        const allRoles = await this.fetchAllRolesRaw();
+        if (!solutionId) {
+            return allRoles;
+        }
+
+        const roleIdsBySolution = await this.fetchRoleIdsBySolution();
+        const roleIds = roleIdsBySolution.get(solutionId.toLowerCase());
+        if (!roleIds || roleIds.size === 0) {
+            return [];
+        }
+        return allRoles.filter((role) => roleIds.has(role.roleid.toLowerCase()));
     }
 
     /**


### PR DESCRIPTION
## Summary

Version 2.0.0 of the **Security Role Comparator** tool. The list below describes the net changes compared to the currently published version.

### Role selection
- Base and comparison role dropdowns are grouped into **Unmanaged** and **Managed** sections; roles that share a name are disambiguated by business unit.
- Each comparison column has a **(Set as Base)** link that swaps that role with the base role and re-runs the comparison in place.
- Base and comparison selectors share a single row and shrink as more roles are added so they stay on one line.
- Last-used base and comparison role selections are remembered per environment.

### Privilege grid
- Privileges are grouped like the built-in security role editor: **Tables** tabs (Core Records, Business Management, Customization, Custom Entities, Business Process Flows, ...) plus separate **Miscellaneous** and **Privacy Related** sections, sourced from the `roleeditorlayout` table.
- Entity rows show both the **display name** and the **schema name**.
- Privilege-to-table resolution uses table metadata (`EntityDefinitions.Privileges`), so tables whose privilege names don't match their logical name (e.g. SystemUser, Activity) and `AppendTo` privileges classify correctly.
- Privilege depth is shown with icons that mirror the security role editor (None, User, Business Unit, Parent-Child BU, Organization), replacing the four-dot indicator.
- Differences are shown with directional icons (green plus when a compared role has more permission than the base, red minus when less), replacing the amber cell shading; cells that match the base are de-emphasized so real differences stand out.
- Light-gray separators divide the role columns; the Entity and Operation columns size to content instead of stretching.

### Combined Permission
<img width="1085" height="907" alt="image" src="https://github.com/user-attachments/assets/1e4eb43a-3172-4d69-bbc4-412ac4053791" />

- A **Combined Permission** option in the row-filter dropdown appends a virtual column showing the net effective permission a user would have if assigned the base role and every comparison role.
- For each privilege the combined value is the highest permission granted by any of the selected roles (Dataverse security is additive), using the precedence None -> User -> Business Unit -> Parent-Child BU -> Organization.
- The grid is filtered to privileges whose combined permission is above None, still honoring any active Group and Operation filters.

### Filtering
- **Row filter** dropdown: All differences (default), More than base, Less than base, Same as base, Show all, or Combined Permission.
- **Group** and **Operation** multi-select filters, each with an **All** shortcut for select/clear-all.
- Operations display and sort in canonical order: Create, Read, Write, Delete, Append, Append To, Assign, Share (with Enable for non-table privileges).
- Search matches entity display name, schema name, operation, and raw privilege name.

## Testing
- `npm run build` (typecheck + Vite build) passes.
