### PR TITLE
Fix Quick Find view layout copying

### DIFF
--- a/tools/view-layout-copier/README.md
+++ b/tools/view-layout-copier/README.md
@@ -16,7 +16,7 @@ View Layout Copier simplifies keeping view layouts consistent across a table. In
 - **Selective copying**: Choose what to copy (all enabled by default):
   - **Column layout** — columns, order, and widths
   - **Sort order** — replaces the targets' sorting
-  - **Components configuration** — custom controls / grid components (`layoutjson`)
+  - **Components configuration** — custom controls / grid components (`layoutjson`); skipped for Quick Find, Lookup, Advanced Find, and personal views, which do not support them
 - **Filters are never copied**: Each target view keeps its own filter criteria by design
 - **Smart query merging**: Attributes referenced by the copied layout are added to the target's fetchxml automatically; related-table (link-entity) columns are carried over *without* their filters
 - **Lookup view safety check**: If a lookup view is selected as a target and the source layout's first column is not the table's primary name column, the tool warns you — lookup views need the name column first to work correctly on forms

--- a/tools/view-layout-copier/README.md
+++ b/tools/view-layout-copier/README.md
@@ -8,7 +8,7 @@ View Layout Copier simplifies keeping view layouts consistent across a table. In
 
 ## Features
 
-- **Solution selector on launch**: Narrow the table list to an unmanaged solution (managed solutions are excluded — they can't be modified), or work across all tables. Defaults to the current user's preferred solution from the maker portal when one is set, otherwise the first unmanaged solution alphabetically
+- **Solution selector on launch**: Narrow the table list to an unmanaged solution (managed solutions are excluded — they can't be modified), or work across all tables. Defaults to the most recently selected solution for the current environment, then the user's maker-portal preference, then the first unmanaged solution alphabetically
 - **Persistent, searchable table list**: Search by display name *or* schema/logical name; the list is alphabetized by display name and stays available on the left for quick switching
 - **View types at a glance**: Every view is badged with its type — Default Public View, Public View, Personal View, Associated View, Advanced Find View, Quick Find View, Lookup View, and more
 - **Personal views included**: Copy to/from personal views (userquery) as well as system views (savedquery)
@@ -25,7 +25,7 @@ View Layout Copier simplifies keeping view layouts consistent across a table. In
 
 ## How to Use
 
-1. **Pick a solution** on the Tables tab to narrow the table list — it's pre-selected using your maker-portal preferred solution when available
+1. **Pick a solution** on the Tables tab to narrow the table list — the last solution used in the current environment is selected when available
 2. **Select a table** from the searchable list on the left
 3. **Choose the source view** whose layout you want to copy — its layout appears in the preview strip
 4. **Check the target views** to apply the layout to

--- a/tools/view-layout-copier/README.md
+++ b/tools/view-layout-copier/README.md
@@ -19,7 +19,7 @@ View Layout Copier simplifies keeping view layouts consistent across a table. In
   - **Components configuration** — custom controls / grid components (`layoutjson`); skipped for Quick Find, Lookup, Advanced Find, and personal views, which do not support them
 - **Filters are never copied**: Each target view keeps its own filter criteria by design
 - **Smart query merging**: Attributes referenced by the copied layout are added to the target's fetchxml automatically; related-table (link-entity) columns are carried over *without* their filters
-- **Lookup view safety check**: If a lookup view is selected as a target and the source layout's first column is not the table's primary name column, the tool warns you — lookup views need the name column first to work correctly on forms
+- **Lookup view safety block**: A lookup target cannot receive a column layout unless the table's primary name column is first, preventing broken lookup behavior on forms
 - **Single publish**: Customizations are published once per copy operation, not once per view
 - **Real-time progress**: Per-view status with details of what was changed
 

--- a/tools/view-layout-copier/README.md
+++ b/tools/view-layout-copier/README.md
@@ -55,6 +55,8 @@ npm run dev
 npm run build
 ```
 
+Each production build increments the package's patch version before bundling.
+
 When run locally outside PPTB (`npm run dev`), the tool starts in **demo mode** with an in-memory mock of the Dataverse API and sample tables/views, so the whole flow — including copying — can be exercised in a plain browser. Production builds require PPTB.
 
 ## License

--- a/tools/view-layout-copier/README.md
+++ b/tools/view-layout-copier/README.md
@@ -36,6 +36,7 @@ View Layout Copier simplifies keeping view layouts consistent across a table. In
 - **Built with**: React 18 + TypeScript + Vite (no UI framework dependencies)
 - **PPTB Integration**: Uses `@pptb/types` (`window.dataverseAPI` / `window.toolboxAPI`)
 - **Dataverse**: Reads `savedquery`/`userquery`, merges `layoutxml`/`fetchxml`/`layoutjson`, publishes via `PublishXml`
+- **FetchXML updates**: Includes `returnedtypecode` with every FetchXML write, as required by Dataverse for Quick Find and other saved-query updates
 - **Theme aware**: Follows the PPTB light/dark theme
 
 ## Installation

--- a/tools/view-layout-copier/npm-shrinkwrap.json
+++ b/tools/view-layout-copier/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@power-maverick/tool-view-layout-copier",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "GPL-2.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/tools/view-layout-copier/npm-shrinkwrap.json
+++ b/tools/view-layout-copier/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@power-maverick/tool-view-layout-copier",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "GPL-2.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/tools/view-layout-copier/npm-shrinkwrap.json
+++ b/tools/view-layout-copier/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@power-maverick/tool-view-layout-copier",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "GPL-2.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/tools/view-layout-copier/npm-shrinkwrap.json
+++ b/tools/view-layout-copier/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@power-maverick/tool-view-layout-copier",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "GPL-2.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/tools/view-layout-copier/package.json
+++ b/tools/view-layout-copier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
   "displayName": "View Layout Copier",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Copy column layout, sort order and components configuration from one view to multiple views of the same table in a single operation",
   "icon": "icons/layoutReplicator.svg",
   "contributors": [

--- a/tools/view-layout-copier/package.json
+++ b/tools/view-layout-copier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
   "displayName": "View Layout Copier",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Copy column layout, sort order and components configuration from one view to multiple views of the same table in a single operation",
   "icon": "icons/layoutReplicator.svg",
   "contributors": [
@@ -21,6 +21,7 @@
   },
   "type": "module",
   "scripts": {
+    "prebuild": "npm run version-stable",
     "build": "vite build",
     "dev": "vite",
     "preview": "vite preview",

--- a/tools/view-layout-copier/package.json
+++ b/tools/view-layout-copier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
   "displayName": "View Layout Copier",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Copy column layout, sort order and components configuration from one view to multiple views of the same table in a single operation",
   "icon": "icons/layoutReplicator.svg",
   "contributors": [

--- a/tools/view-layout-copier/package.json
+++ b/tools/view-layout-copier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@power-maverick/tool-view-layout-copier",
   "displayName": "View Layout Copier",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Copy column layout, sort order and components configuration from one view to multiple views of the same table in a single operation",
   "icon": "icons/layoutReplicator.svg",
   "contributors": [

--- a/tools/view-layout-copier/src/App.tsx
+++ b/tools/view-layout-copier/src/App.tsx
@@ -189,8 +189,8 @@ function App() {
         });
     };
 
-    const lookupWarningViews = useMemo(() => {
-        if (!sourceView || !table) return [];
+    const lookupBlockedViews = useMemo(() => {
+        if (!options.columnLayout || !sourceView || !table) return [];
         let firstColumn = "";
         try {
             firstColumn = parseLayoutColumns(sourceView.layoutxml).filter((c) => !c.isHidden)[0]?.name ?? "";
@@ -199,10 +199,14 @@ function App() {
         }
         if (firstColumn === table.primaryNameAttribute) return [];
         return views.filter((v) => targetIds.has(v.id) && isLookupView(v)).map((v) => v.name);
-    }, [sourceView, table, targetIds, views]);
+    }, [options.columnLayout, sourceView, table, targetIds, views]);
 
     const handleCopy = async () => {
         if (!sourceView || !table || targetIds.size === 0) return;
+        if (lookupBlockedViews.length > 0) {
+            showError(`Copy blocked: lookup views must keep ${table.primaryNameAttribute} as their first column.`);
+            return;
+        }
 
         const targets = views.filter((v) => targetIds.has(v.id));
         const progress: CopyResultItem[] = targets.map((v) => ({ viewId: v.id, viewName: v.name, status: "pending" }));
@@ -384,7 +388,7 @@ function App() {
                             options={options}
                             sourceView={sourceView}
                             targetCount={targetIds.size}
-                            lookupWarningViews={lookupWarningViews}
+                            lookupBlockedViews={lookupBlockedViews}
                             primaryNameAttribute={table?.primaryNameAttribute ?? "name"}
                             isCopying={isCopying}
                             results={results}

--- a/tools/view-layout-copier/src/App.tsx
+++ b/tools/view-layout-copier/src/App.tsx
@@ -12,6 +12,36 @@ import { buildTargetLayoutXml, mergeFetchXml, parseLayoutColumns } from "./utils
 import { version as APP_VERSION } from "../package.json";
 
 const client = new DataverseClient();
+const RECENT_SOLUTION_STORAGE_PREFIX = "pptb:view-layout-copier:recent-solution";
+
+function recentSolutionStorageKey(environmentUrl: string): string | null {
+    if (!environmentUrl) return null;
+    try {
+        return `${RECENT_SOLUTION_STORAGE_PREFIX}:${new URL(environmentUrl).origin}`;
+    } catch {
+        return `${RECENT_SOLUTION_STORAGE_PREFIX}:${environmentUrl}`;
+    }
+}
+
+function readRecentSolutionId(environmentUrl: string): string | null {
+    const key = recentSolutionStorageKey(environmentUrl);
+    if (!key) return null;
+    try {
+        return window.localStorage.getItem(key);
+    } catch {
+        return null;
+    }
+}
+
+function saveRecentSolutionId(environmentUrl: string, solutionId: string): void {
+    const key = recentSolutionStorageKey(environmentUrl);
+    if (!key || !solutionId) return;
+    try {
+        window.localStorage.setItem(key, solutionId);
+    } catch {
+        // Browser storage is optional; preferred-solution fallback remains available.
+    }
+}
 
 function App() {
     const isDemoMode = (window as any).__PPTB_MOCK__ === true;
@@ -80,9 +110,11 @@ function App() {
                 return;
             }
 
+            let activeConnectionUrl = "";
             try {
                 const activeConnection = await window.toolboxAPI?.connections.getActiveConnection();
-                setConnectionUrl(activeConnection?.url || "");
+                activeConnectionUrl = activeConnection?.url || "";
+                setConnectionUrl(activeConnectionUrl);
             } catch (e) {
                 console.error("Failed to get connection:", e);
             }
@@ -92,10 +124,14 @@ function App() {
                 setSolutions(solutionList);
                 setTables(tableList);
 
-                // Default to the user's maker-portal preferred solution when it's one of the
-                // unmanaged solutions we can write to; otherwise fall back to the first
-                // alphabetically. Leaves "All tables" unselected only when no solutions exist.
-                const defaultSolutionId = solutionList.find((s) => s.id === preferredSolutionId)?.id ?? solutionList[0]?.id ?? "";
+                // Prefer the last solution selected in this environment, then the maker-portal
+                // preference, then the first unmanaged solution alphabetically.
+                const recentSolutionId = readRecentSolutionId(activeConnectionUrl);
+                const defaultSolutionId =
+                    solutionList.find((s) => s.id.toLowerCase() === recentSolutionId?.toLowerCase())?.id ??
+                    solutionList.find((s) => s.id.toLowerCase() === preferredSolutionId?.toLowerCase())?.id ??
+                    solutionList[0]?.id ??
+                    "";
                 if (defaultSolutionId) {
                     setSelectedSolutionId(defaultSolutionId);
                     setSolutionTableIds(await fetchSolutionTableIds(defaultSolutionId));
@@ -119,6 +155,7 @@ function App() {
             setSolutionTableIds(null);
             return;
         }
+        saveRecentSolutionId(connectionUrl, solutionId);
         setLoadingTables(true);
         const ids = await fetchSolutionTableIds(solutionId);
         setSolutionTableIds(ids);

--- a/tools/view-layout-copier/src/App.tsx
+++ b/tools/view-layout-copier/src/App.tsx
@@ -6,7 +6,7 @@ import { SolutionPicker } from "./components/SolutionPicker";
 import { TableSidebar } from "./components/TableSidebar";
 import { ViewListPanel } from "./components/ViewListPanel";
 import { CopyOptions, CopyResultItem, Solution, TableInfo, ViewInfo } from "./models/interfaces";
-import { isLookupView, viewTypeRank } from "./models/viewTypes";
+import { getViewTypeLabel, isLookupView, supportsComponents, viewTypeRank } from "./models/viewTypes";
 import { DataverseClient, ViewUpdatePayload } from "./utils/DataverseClient";
 import { buildTargetLayoutXml, mergeFetchXml, parseLayoutColumns } from "./utils/layoutUtils";
 import { version as APP_VERSION } from "../package.json";
@@ -249,12 +249,16 @@ function App() {
                     notes.push(`skipped sort on ${merge.droppedOrders.join(", ")} (related table not in target)`);
                 }
 
-                if (options.components && sourceView.layoutjson && !target.isPersonal) {
-                    payload.layoutjson = sourceView.layoutjson;
+                if (options.components && sourceView.layoutjson) {
+                    if (supportsComponents(target)) {
+                        payload.layoutjson = sourceView.layoutjson;
+                    } else {
+                        notes.push(`skipped components (${getViewTypeLabel(target)} does not support them)`);
+                    }
                 }
 
                 if (Object.keys(payload).length === 0) {
-                    progress[i] = { ...progress[i], status: "success", message: "Nothing to change" };
+                    progress[i] = { ...progress[i], status: "success", message: notes.length > 0 ? notes.join("; ") : "Nothing to change" };
                 } else {
                     await client.updateView(target, payload);
                     if (!target.isPersonal) systemViewUpdated = true;

--- a/tools/view-layout-copier/src/components/CopyActionsBar.tsx
+++ b/tools/view-layout-copier/src/components/CopyActionsBar.tsx
@@ -5,7 +5,7 @@ interface CopyActionsBarProps {
     sourceView?: ViewInfo;
     targetCount: number;
     /** names of selected lookup-view targets when the source's first column is not the primary name attribute */
-    lookupWarningViews: string[];
+    lookupBlockedViews: string[];
     primaryNameAttribute: string;
     isCopying: boolean;
     results: CopyResultItem[];
@@ -19,7 +19,7 @@ export function CopyActionsBar({
     options,
     sourceView,
     targetCount,
-    lookupWarningViews,
+    lookupBlockedViews,
     primaryNameAttribute,
     isCopying,
     results,
@@ -29,19 +29,19 @@ export function CopyActionsBar({
     onReset,
 }: CopyActionsBarProps) {
     const nothingToCopy = !options.columnLayout && !options.sortOrder && !options.components;
-    const canCopy = !!sourceView && targetCount > 0 && !nothingToCopy && !isCopying;
+    const canCopy = !!sourceView && targetCount > 0 && lookupBlockedViews.length === 0 && !nothingToCopy && !isCopying;
 
     return (
         <section className="panel copy-actions-bar">
-            {lookupWarningViews.length > 0 && (
+            {lookupBlockedViews.length > 0 && (
                 <div className="warning-box" role="alert">
-                    <strong>Lookup view warning</strong>
+                    <strong>Lookup view update blocked</strong>
                     <p>
                         A lookup view should always have <code>{primaryNameAttribute}</code> (the primary name column) as its <em>first</em> column, otherwise lookups will have difficulty working on
-                        forms. The source layout's first column is different, and it would be applied to:
+                        forms. The source layout's first column is different, so the column layout cannot be applied to:
                     </p>
                     <ul>
-                        {lookupWarningViews.map((name) => (
+                        {lookupBlockedViews.map((name) => (
                             <li key={name}>{name}</li>
                         ))}
                     </ul>

--- a/tools/view-layout-copier/src/mock/mockAPI.ts
+++ b/tools/view-layout-copier/src/mock/mockAPI.ts
@@ -664,6 +664,9 @@ export function installMockAPI(): void {
 
         async update(entityLogicalName: string, id: string, record: Record<string, unknown>): Promise<void> {
             await delay(500);
+            if (record.fetchxml && !record.returnedtypecode) {
+                throw new Error("Dataverse update failed: 0x80040216: An unexpected error occurred.");
+            }
             const view: any =
                 entityLogicalName === "savedquery" ? SYSTEM_VIEWS.find((v) => v.savedqueryid === id) : entityLogicalName === "userquery" ? PERSONAL_VIEWS.find((v) => v.userqueryid === id) : undefined;
             if (!view) {

--- a/tools/view-layout-copier/src/models/interfaces.ts
+++ b/tools/view-layout-copier/src/models/interfaces.ts
@@ -21,6 +21,7 @@ export interface ViewInfo {
     fetchxml: string;
     layoutxml: string;
     layoutjson?: string | null;
+    returnedtypecode: string;
     querytype: number;
     isDefault: boolean;
     /** true when the view is a personal view (userquery) instead of a system view (savedquery) */

--- a/tools/view-layout-copier/src/models/viewTypes.ts
+++ b/tools/view-layout-copier/src/models/viewTypes.ts
@@ -70,6 +70,16 @@ export function isLookupView(view: Pick<ViewInfo, "querytype">): boolean {
     return view.querytype === QUERY_TYPE.LOOKUP_VIEW;
 }
 
+/** Grid components are not supported by personal or special-purpose search views. */
+export function supportsComponents(view: Pick<ViewInfo, "querytype" | "isPersonal">): boolean {
+    return (
+        !view.isPersonal &&
+        view.querytype !== QUERY_TYPE.ADVANCED_SEARCH &&
+        view.querytype !== QUERY_TYPE.QUICK_FIND_SEARCH &&
+        view.querytype !== QUERY_TYPE.LOOKUP_VIEW
+    );
+}
+
 /** Sort order used to present views: default public first, then public, then the rest, personal last */
 export function viewTypeRank(view: Pick<ViewInfo, "querytype" | "isDefault" | "isPersonal">): number {
     if (view.isPersonal) return 90;

--- a/tools/view-layout-copier/src/utils/DataverseClient.ts
+++ b/tools/view-layout-copier/src/utils/DataverseClient.ts
@@ -13,6 +13,7 @@ export interface ViewUpdatePayload {
     fetchxml?: string;
     layoutxml?: string;
     layoutjson?: string;
+    returnedtypecode?: string;
 }
 
 export class DataverseClient {
@@ -127,6 +128,7 @@ export class DataverseClient {
                 fetchxml: v.fetchxml,
                 layoutxml: v.layoutxml,
                 layoutjson: v.layoutjson ?? null,
+                returnedtypecode: tableLogicalName,
                 querytype: v.querytype ?? 0,
                 isDefault: v.isdefault === true,
                 isPersonal: false,
@@ -138,6 +140,7 @@ export class DataverseClient {
                 fetchxml: v.fetchxml,
                 layoutxml: v.layoutxml,
                 layoutjson: null,
+                returnedtypecode: tableLogicalName,
                 querytype: v.querytype ?? 0,
                 isDefault: false,
                 isPersonal: true,
@@ -161,7 +164,8 @@ export class DataverseClient {
     /** Update a system or personal view with the merged layout/fetch changes */
     async updateView(view: ViewInfo, payload: ViewUpdatePayload): Promise<void> {
         const entityName = view.isPersonal ? "userquery" : "savedquery";
-        await window.dataverseAPI.update(entityName, view.id, payload as Record<string, unknown>);
+        const updatePayload = payload.fetchxml ? { ...payload, returnedtypecode: view.returnedtypecode } : payload;
+        await window.dataverseAPI.update(entityName, view.id, updatePayload as Record<string, unknown>);
     }
 
     /** Publish the table once after all system view updates (personal views don't need publishing) */

--- a/tools/view-layout-copier/src/utils/layoutUtils.ts
+++ b/tools/view-layout-copier/src/utils/layoutUtils.ts
@@ -95,9 +95,10 @@ export function parseSortOrders(fetchXml: string): SortOrder[] {
 }
 
 /**
- * Build the target's new layoutxml: the source grid's rows (the column definitions)
- * replace the target's, while the target keeps its own <grid> attributes
- * (jump, select, icon, preview, ...) which differ between view types.
+ * Build the target's new layoutxml: the source row's cells (the column definitions)
+ * replace the target's, while the target keeps its own <grid> and <row> attributes.
+ * Those attributes differ between view types and include metadata required by
+ * special-purpose views such as Quick Find.
  */
 export function buildTargetLayoutXml(sourceLayoutXml: string, targetLayoutXml: string): string {
     const sourceDoc = parseXml(sourceLayoutXml);
@@ -109,11 +110,17 @@ export function buildTargetLayoutXml(sourceLayoutXml: string, targetLayoutXml: s
         throw new Error("layoutxml has no <grid> element");
     }
 
-    for (const row of directChildren(targetGrid, "row")) {
-        targetGrid.removeChild(row);
+    const sourceRow = directChildren(sourceGrid, "row")[0];
+    const targetRow = directChildren(targetGrid, "row")[0];
+    if (!sourceRow || !targetRow) {
+        throw new Error("layoutxml has no <row> element");
     }
-    for (const row of directChildren(sourceGrid, "row")) {
-        targetGrid.appendChild(targetDoc.importNode(row, true));
+
+    while (targetRow.firstChild) {
+        targetRow.removeChild(targetRow.firstChild);
+    }
+    for (const cell of directChildren(sourceRow, "cell")) {
+        targetRow.appendChild(targetDoc.importNode(cell, true));
     }
 
     return serializeXml(targetDoc);


### PR DESCRIPTION
## Summary
- Fix to allow column layout and sort-order updates to complete for Quick Find views
- Skip `layoutjson` component configuration for Quick Find, Lookup, Advanced Find, and personal targets
- Block column-layout writes to Lookup views unless the primary name attribute is the first visible column
- Default to the most recently selected solution per environment, then maker preferred, then alphabetical

## Background
Dataverse requires the target entity context (`returnedtypecode`) in the same PATCH request whenever `fetchxml` changes. Without it, Quick Find saved-query updates can fail with `0x80040216: An unexpected error occurred`.